### PR TITLE
Reduce idle CPU/battery cost of background app/browser watchers

### DIFF
--- a/src-tauri/src/app_watcher.rs
+++ b/src-tauri/src/app_watcher.rs
@@ -51,7 +51,15 @@ use tauri::{AppHandle, Emitter};
 
 pub type BlockedApps = Arc<RwLock<HashSet<String>>>;
 
-const POLL_INTERVAL: Duration = Duration::from_millis(1000);
+/// Steady-state poll cadence while a schedule is active but no blocked
+/// app is currently being tracked — the common idle case. We only need
+/// to notice a newly-launched blocked app within a couple of seconds,
+/// so polling slower here roughly halves background CPU/battery cost
+/// versus the old fixed 1s sweep.
+const POLL_INTERVAL: Duration = Duration::from_millis(2000);
+/// Faster cadence while at least one PID is mid-countdown (PreQuit /
+/// PostQuit) so the warning overlay and grace timers stay responsive.
+const POLL_INTERVAL_ACTIVE: Duration = Duration::from_millis(1000);
 /// After the user clicks "Let's go!", how long they get to save +
 /// manually quit before the watcher sends the polite Cmd-Q.
 const PREQUIT_DURATION: Duration = Duration::from_secs(30);
@@ -376,9 +384,20 @@ fn run(
     stop: Arc<AtomicBool>,
 ) {
     let mut entries: HashMap<sysinfo::Pid, PidEntry> = HashMap::new();
+    // One `System` kept alive across sweeps so sysinfo does incremental
+    // diffs — and caches each process's exe path — instead of building a
+    // fresh table and re-reading the whole process list cold every tick.
+    let mut sys = sysinfo::System::new();
     while !stop.load(Ordering::SeqCst) {
-        sweep(app.as_ref(), &apps, &pending_warning_apps, &mut entries);
-        std::thread::sleep(POLL_INTERVAL);
+        sweep(app.as_ref(), &apps, &pending_warning_apps, &mut entries, &mut sys);
+        // Poll fast only while a countdown is in flight; otherwise idle
+        // at the slower cadence to keep background CPU / battery low.
+        let interval = if entries.is_empty() {
+            POLL_INTERVAL
+        } else {
+            POLL_INTERVAL_ACTIVE
+        };
+        std::thread::sleep(interval);
     }
     // On stop: clear any in-flight warnings so the UI doesn't keep
     // showing a stale modal after the watcher's gone. Mid-block PIDs
@@ -408,8 +427,9 @@ fn sweep(
     apps: &BlockedApps,
     pending_warning_apps: &PendingWarningApps,
     entries: &mut HashMap<sysinfo::Pid, PidEntry>,
+    sys: &mut sysinfo::System,
 ) {
-    use sysinfo::{ProcessesToUpdate, System};
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
 
     let blocked: Vec<String> = match apps.read() {
         Ok(g) => g.iter().cloned().collect(),
@@ -444,8 +464,17 @@ fn sweep(
         return;
     }
 
-    let mut sys = System::new();
-    sys.refresh_processes(ProcessesToUpdate::All, true);
+    // Refresh only what we match on: the process name (always present)
+    // plus the executable path. `OnlyIfNotSet` fetches the exe once per
+    // PID and caches it on the persistent `System`, so steady-state
+    // sweeps skip the per-process exe syscall entirely. We deliberately
+    // skip CPU/memory/disk/user/cmd/env refresh — the default
+    // `refresh_processes` pulls all of that for every process each tick.
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing().with_exe(UpdateKind::OnlyIfNotSet),
+    );
 
     let now = Instant::now();
     let mut still_alive: HashSet<sysinfo::Pid> = HashSet::new();

--- a/src-tauri/src/enforcer.rs
+++ b/src-tauri/src/enforcer.rs
@@ -843,9 +843,15 @@ fn log_non_compliant_summary(
 // ---- Process detection + quit -----------------------------------------
 
 fn running_browsers() -> std::collections::HashSet<BrowserKey> {
-    use sysinfo::{ProcessesToUpdate, System};
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
     let mut sys = System::new();
-    sys.refresh_processes(ProcessesToUpdate::All, true);
+    // We only match on process names — skip the default CPU/memory/disk/
+    // exe refresh that `refresh_processes` does for every process.
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing(),
+    );
     let mut out = std::collections::HashSet::new();
     for &key in BrowserKey::enforced() {
         for name in key.process_names() {

--- a/src-tauri/src/watchdog.rs
+++ b/src-tauri/src/watchdog.rs
@@ -147,10 +147,18 @@ pub fn register() {
             TASK_NAME,
             "/TR",
             &task_run,
+            // Every 5 minutes rather than every 1: the watchdog only
+            // needs to respawn the app if the user has killed it, which
+            // is rare. A 1-minute cadence meant a Task Scheduler wake +
+            // wscript/cmd/tasklist process spawn every 60s forever, even
+            // fully idle — a steady battery drain on laptops (it also
+            // hides from the app's own CPU line, being a separate
+            // process). 5 minutes keeps self-heal effective while cutting
+            // the wake rate 5x.
             "/SC",
             "MINUTE",
             "/MO",
-            "1",
+            "5",
             "/RL",
             "LIMITED",
             "/F",


### PR DESCRIPTION
## Why

I found high, constant battery/CPU impact (~9% CPU, dropping to ~4% only when all schedules were paused) that persisted even with all browsers closed and across enforcement styles.

Root cause: the in-process **app watcher** polls the *entire* system process list **once per second** whenever any app-blocking schedule is active. Each sweep built a fresh `sysinfo::System` and refreshed *all* per-process fields. Because it watches every running app (not browsers), it stayed high regardless of browser state, and dropped only when the blocklist emptied (schedules paused → early return). The same loop runs on macOS and Windows.

## What changed

**`app_watcher.rs`**
- Reuse a single `System` across sweeps (was `System::new()` every tick) → incremental diffs + cached exe paths instead of cold-reading the whole process table each second.
- `refresh_processes_specifics(..., ProcessRefreshKind::nothing().with_exe(OnlyIfNotSet))` → refresh only name + exe (what we match on), skipping the default CPU/memory/disk/user/cmd/env refresh for every process.
- Adaptive cadence: **2s** when idle (schedule active, no app being tracked), dropping to **1s** only while a PID is mid-countdown (`PreQuit`/`PostQuit`) so the warning overlay and grace timers stay responsive.

**`enforcer.rs`**
- `running_browsers()` uses `ProcessRefreshKind::nothing()` (it only matches on process names) — same minimal-refresh win on each enforcer tick during an active block.

**`watchdog.rs` (Windows-only)**
- Task Scheduler cadence `/MO 1` → `/MO 5` (every 5 min instead of every minute). The watchdog only respawns the app if the user killed it; the 1-minute cadence meant a wake + `wscript`/`cmd`/`tasklist` spawn every 60s forever, even fully idle — a steady laptop battery drain that also hid from the app's own CPU line.

## Reviewer notes
- B + C and the enforcer change live in shared `cfg(any(macos, windows))` paths, so both platforms benefit; the watchdog change is Windows-specific.
- The watchdog cadence only takes effect once `register` re-runs and overwrites the existing task (uses `/F`), i.e. on the next app launch — existing installs keep the 1-min task until then.
- `cargo check --features desktop` passes (only pre-existing dead-code warnings).
- Possible follow-up: an event-driven `NSWorkspace` / Win32 launch-notification rewrite would remove the idle polling entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)