### PR TITLE
Write redd-block-data.json atomically to prevent torn reads dropping blocks

### DIFF
--- a/src-tauri/src/commands/blocking_method_cmd.rs
+++ b/src-tauri/src/commands/blocking_method_cmd.rs
@@ -88,9 +88,6 @@ fn read_data(path: &std::path::Path) -> Option<Value> {
 }
 
 fn write_data(path: &std::path::Path, data: &Value) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let body = serde_json::to_vec_pretty(data)?;
-    std::fs::write(path, body)
+    super::data::write_data_file_atomic(path, &body)
 }

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -367,6 +367,61 @@ fn set_shared_permissions(_path: &std::path::Path) {
     // On Windows, %PROGRAMDATA% is already accessible to all users by default.
 }
 
+/// Atomically replace the data file: write to a temp file in the same
+/// directory, apply shared permissions, then rename over the destination.
+///
+/// The data file is the single source of truth for active blocking and
+/// is re-read continuously by other threads and processes — the
+/// Automation watcher (1 s tick), the browser-spawned native host (2 s
+/// mtime poll), and the enforcer (5 s tick). A plain truncate-and-write
+/// can be observed half-written; the readers then fail the JSON parse
+/// and treat the blocklist as empty, momentarily dropping enforcement
+/// (and un-parking tabs from the block page). rename() within one
+/// directory is atomic on APFS and NTFS, so readers see either the old
+/// or the new complete file, never a torn one.
+pub(crate) fn write_data_file_atomic(
+    path: &std::path::Path,
+    contents: &[u8],
+) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    // Unique per process AND per call — concurrent Tauri commands may
+    // save from different threads of the same process.
+    static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("redd-block-data.json");
+    let tmp = path.with_file_name(format!(
+        ".{file_name}.tmp-{}-{}",
+        std::process::id(),
+        TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+
+    let result = (|| {
+        let mut file = fs::File::create(&tmp)?;
+        file.write_all(contents)?;
+        // Flush to disk before the rename so a crash can't leave the
+        // canonical path pointing at a not-yet-persisted temp file.
+        file.sync_all()?;
+        drop(file);
+        // The rename gives the destination the temp file's permissions,
+        // so the shared-file mode must be applied before the swap.
+        set_shared_permissions(&tmp);
+        fs::rename(&tmp, path)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    result
+}
+
 /// Ensure the parent directory for the data file exists.
 fn ensure_data_dir(path: &std::path::Path) -> Result<(), String> {
     if let Some(parent) = path.parent() {
@@ -486,8 +541,7 @@ pub fn load_data(app: AppHandle) -> Result<AppData, String> {
         let mut data: AppData = serde_json::from_str(&content).map_err(|e| e.to_string())?;
         if normalize_eula_state(&mut data) {
             let migrated = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
-            fs::write(&data_path, &migrated).map_err(|e| e.to_string())?;
-            set_shared_permissions(&data_path);
+            write_data_file_atomic(&data_path, migrated.as_bytes()).map_err(|e| e.to_string())?;
         }
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         super::app_blocking::sync_blocked_apps_from_disk(&app);
@@ -500,8 +554,8 @@ pub fn load_data(app: AppHandle) -> Result<AppData, String> {
                 let mut data: AppData = serde_json::from_str(&content).map_err(|e| e.to_string())?;
                 if normalize_eula_state(&mut data) {
                     let migrated = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
-                    fs::write(&source_path, &migrated).map_err(|e| e.to_string())?;
-                    set_shared_permissions(&source_path);
+                    write_data_file_atomic(&source_path, migrated.as_bytes())
+                        .map_err(|e| e.to_string())?;
                 }
                 return Ok(data);
             }
@@ -522,8 +576,7 @@ pub fn load_data(app: AppHandle) -> Result<AppData, String> {
             normalize_eula_state(&mut data);
             // Save to new location so migration only happens once
             let migrated = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
-            fs::write(&data_path, &migrated).map_err(|e| e.to_string())?;
-            set_shared_permissions(&data_path);
+            write_data_file_atomic(&data_path, migrated.as_bytes()).map_err(|e| e.to_string())?;
             Ok(data)
         } else {
             Ok(AppData::default())
@@ -551,8 +604,7 @@ pub fn save_data(app: AppHandle, mut data: AppData) -> Result<(), String> {
     preserve_backend_settings(&data_path, &mut data);
 
     let content = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
-    fs::write(&data_path, &content).map_err(|e| e.to_string())?;
-    set_shared_permissions(&data_path);
+    write_data_file_atomic(&data_path, content.as_bytes()).map_err(|e| e.to_string())?;
 
     #[cfg(target_os = "macos")]
     crate::app_group::maybe_mirror_after_save(&data_path, content.as_bytes());

--- a/src-tauri/src/commands/enforcement_toggle.rs
+++ b/src-tauri/src/commands/enforcement_toggle.rs
@@ -101,9 +101,6 @@ fn read_data(app: &tauri::AppHandle) -> Option<Value> {
 }
 
 fn write_data(path: &std::path::Path, data: &Value) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let body = serde_json::to_vec_pretty(data)?;
-    std::fs::write(path, body)
+    super::data::write_data_file_atomic(path, &body)
 }

--- a/src-tauri/src/commands/grace.rs
+++ b/src-tauri/src/commands/grace.rs
@@ -104,9 +104,6 @@ fn read_data(app: &tauri::AppHandle) -> Option<Value> {
 }
 
 fn write_data(path: &std::path::Path, data: &Value) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let body = serde_json::to_vec_pretty(data)?;
-    std::fs::write(path, body)
+    super::data::write_data_file_atomic(path, &body)
 }

--- a/src-tauri/src/web_automation.rs
+++ b/src-tauri/src/web_automation.rs
@@ -1236,7 +1236,7 @@ mod tests {
         let p = std::path::Path::new("/Applications/ReDD Blocker.app/Contents/Resources/blocked/blocked.html");
         assert_eq!(
             path_to_file_url(p),
-            "file:///Applications/ReDD%20Block.app/Contents/Resources/blocked/blocked.html"
+            "file:///Applications/ReDD%20Blocker.app/Contents/Resources/blocked/blocked.html"
         );
     }
 }


### PR DESCRIPTION
## Problem

`redd-block-data.json` is the single source of truth for "what is blocked right now", and it is re-read continuously by independent readers:

- the macOS Automation watcher (1 s tick),
- the browser-spawned native-messaging host (2 s **mtime** poll — mtime changes at the *start* of a write, so it actively tends to read mid-write),
- the compliance enforcer (5 s tick).

Every writer used a plain truncate-and-write (`fs::write`), so a reader could observe a half-written file. `derive_payload()` treats a JSON parse failure as an empty blocklist, which fails open: the extension is pushed an empty list and clears blocking, and the Automation watcher's "no domains → restore parked tabs" logic un-parks tabs from the block page. Users could hit this window on every block edit or settings save.

## Fix

New `write_data_file_atomic()` helper in `commands/data.rs`: write to a uniquely-named temp file in the same directory, `sync_all()`, apply the shared-file permissions to the temp file (rename gives the destination the temp file's mode), then `rename()` over the destination — atomic on both APFS and NTFS, and Windows readers using std's default share flags are unaffected by the swap. On failure the temp file is cleaned up.

All data-file writers now go through it:

- `save_data` and the three `load_data` migration/EULA-normalization writes (`commands/data.rs`)
- `set_enforcement_enabled` (`commands/enforcement_toggle.rs`)
- `set_extension_grace_seconds` (`commands/grace.rs`)
- `set_blocking_method` (`commands/blocking_method_cmd.rs`)

(The settings commands previously wrote without re-applying shared permissions; going through the helper also fixes that.)

Also includes a one-line fix for `web_automation::tests::file_url_encodes_spaces`, which had been failing since the product rename (expected URL still said "ReDD Block.app").

## Testing

- `cargo check` clean (only pre-existing warnings)
- `cargo test --lib`: 29 passed, 0 failed

## Not addressed (follow-ups)

- `derive_payload()` still fails open on a genuinely corrupt/missing file; keeping a last-known-good payload would be a further hardening step.
- `preserve_backend_settings` / the settings commands still do unlocked read-modify-write, so a lost-update race between concurrent writers remains possible (much rarer than the torn-read issue fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)