### PR TITLE
Replace hand-rolled file-URL encoder with url::Url::from_file_path

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3459,6 +3459,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tokio",
+ "url",
  "windows 0.61.3",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+url = "2"
 log = "0.4"
 dirs = "5"
 lazy_static = "1.5"

--- a/src-tauri/src/commands/web_automation.rs
+++ b/src-tauri/src/commands/web_automation.rs
@@ -37,7 +37,14 @@ fn resolve_block_page_url(app: &AppHandle) -> Option<String> {
             page.display()
         );
     }
-    Some(web_automation::path_to_file_url(&page))
+    let url = web_automation::path_to_file_url(&page);
+    if url.is_none() {
+        log::warn!(
+            "web_automation: could not build file:// URL for {}",
+            page.display()
+        );
+    }
+    url
 }
 
 /// Start the automation watcher if not already running. Idempotent.

--- a/src-tauri/src/web_automation.rs
+++ b/src-tauri/src/web_automation.rs
@@ -1233,10 +1233,13 @@ mod tests {
 
     #[test]
     fn file_url_encodes_spaces() {
-        let p = std::path::Path::new("/Applications/ReDD Blocker.app/Contents/Resources/blocked/blocked.html");
+        // Deliberately not the real bundle name — this test is about
+        // percent-encoding, and tying it to the product name broke it
+        // once already when the app was renamed.
+        let p = std::path::Path::new("/Applications/Some App.app/Contents/Resources/blocked page.html");
         assert_eq!(
             path_to_file_url(p),
-            "file:///Applications/ReDD%20Block.app/Contents/Resources/blocked/blocked.html"
+            "file:///Applications/Some%20App.app/Contents/Resources/blocked%20page.html"
         );
     }
 }

--- a/src-tauri/src/web_automation.rs
+++ b/src-tauri/src/web_automation.rs
@@ -1144,36 +1144,13 @@ fn hex_val(b: u8) -> Option<u8> {
     }
 }
 
-/// Turn a filesystem path into a `file://` URL, percent-encoding each
-/// segment (the app bundle path contains a space: "ReDD Blocker.app").
-pub fn path_to_file_url(path: &std::path::Path) -> String {
-    let mut url = String::from("file://");
-    for component in path.to_string_lossy().split('/') {
-        if component.is_empty() {
-            continue;
-        }
-        url.push('/');
-        url.push_str(&pct_encode_path_segment(component));
-    }
-    url
-}
-
-/// Like `pct_encode` but also preserves a handful of path-safe sub-delims
-/// so the URL stays readable; the space in "ReDD Blocker" becomes %20.
-fn pct_encode_path_segment(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for &b in s.as_bytes() {
-        let keep = b.is_ascii_alphanumeric()
-            || matches!(b, b'-' | b'_' | b'.' | b'~' | b'!' | b'$' | b'&' | b'(' | b')' | b'+' | b',' | b'=' | b'@');
-        if keep {
-            out.push(b as char);
-        } else {
-            out.push('%');
-            out.push(hex_digit(b >> 4));
-            out.push(hex_digit(b & 0x0f));
-        }
-    }
-    out
+/// Turn an absolute filesystem path into a `file://` URL. Delegates to
+/// the `url` crate rather than hand-rolling percent-encoding — the app
+/// bundle path can contain spaces and non-ASCII, and a home-grown
+/// encoder already broke once. Returns None for relative paths, which
+/// `Url::from_file_path` rejects.
+pub fn path_to_file_url(path: &std::path::Path) -> Option<String> {
+    url::Url::from_file_path(path).ok().map(String::from)
 }
 
 #[cfg(test)]
@@ -1232,14 +1209,19 @@ mod tests {
     }
 
     #[test]
-    fn file_url_encodes_spaces() {
+    fn file_url_encodes_spaces_and_non_ascii() {
         // Deliberately not the real bundle name — this test is about
         // percent-encoding, and tying it to the product name broke it
         // once already when the app was renamed.
-        let p = std::path::Path::new("/Applications/Some App.app/Contents/Resources/blocked page.html");
+        let p = std::path::Path::new("/Applications/Some Äpp.app/Contents/Resources/blocked page.html");
         assert_eq!(
-            path_to_file_url(p),
-            "file:///Applications/Some%20App.app/Contents/Resources/blocked%20page.html"
+            path_to_file_url(p).as_deref(),
+            Some("file:///Applications/Some%20%C3%84pp.app/Contents/Resources/blocked%20page.html")
         );
+    }
+
+    #[test]
+    fn file_url_rejects_relative_paths() {
+        assert_eq!(path_to_file_url(std::path::Path::new("blocked/blocked.html")), None);
     }
 }


### PR DESCRIPTION
## Problem

`web_automation::tests::file_url_encodes_spaces` has been failing since the product rename: it fed `path_to_file_url` a "ReDD Blocker.app" path but asserted the pre-rename `ReDD%20Block.app` URL.

The deeper issue wasn't the stale string — it's that `path_to_file_url` + `pct_encode_path_segment` hand-rolled file-URL percent-encoding, guarded by a single test that itself hardcoded the product name.

## Fix

- Delete the hand-rolled encoder and delegate to `url::Url::from_file_path` — the `url` crate is already in the dependency tree via Tauri (2.5.8 in the lockfile), so declaring it as a direct dependency adds no new compiled code.
- `path_to_file_url` now returns `Option<String>` (the crate rejects relative paths); `resolve_block_page_url` logs and declines to start the watcher in that case, same as the existing missing-resource-dir path.
- Tests cover spaces, non-ASCII, and relative-path rejection using product-agnostic fixture paths, so a future rename can't break them.

Block-page detection is unaffected: `is_block_page_url` keeps its normalization-tolerant fallback (`contains("blocked/blocked.html")`), and the base URL is generated once and used for both the AppleScript `set URL` and the comparison, so both sides stay consistent. The query-string `pct_encode`/`pct_decode` helpers are untouched — they intentionally mirror the extension's `background.js`.

`cargo test --lib`: 30 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)