### PR TITLE
Android: slim bundle (~3.3 MB + ~52 KB JS) and fix low-contrast focus-space chips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,3 +151,17 @@ the webview `chromium` console line from `checkAndroidPermissions`
   tree-shakes their helpers/strings. Value-returning shared helpers
   (`browserIconUrl`, `BROWSER_STORE_LINKS`, …) are intentionally **not** guarded.
   `__ANDROID_BUILD__` is a `define` constant set per build mode in `vite.config.js`.
+- Same technique gates the desktop-only in-app update flow: `checkForAppUpdate`
+  in `src/update-banner.js` is `if (__ANDROID_BUILD__) return;`, which cascades
+  to drop `changelog.js` + the bundled `changelog.md` (~52 KB of startup parse)
+  from Android. `__ANDROID_BUILD__` is the right tool **only when it lets Rollup
+  delete code from the Android bundle** — for plain behavioral branching that
+  must stay in the bundle for desktop, use the runtime `state.isAndroid` flag.
+- Gating the *code* that references a static asset does not by itself drop the
+  asset: Vite emits a file for every `import url from './x.png'` at transform
+  time, before tree-shaking, so a desktop-only image whose only reference is
+  DCE'd is left orphaned in the APK. The `pruneOrphanAndroidAssets` plugin in
+  `vite.config.js` deletes image/video assets referenced by zero chunks/CSS on
+  Android (recovered ~3.3 MB: the welcome video + browser-setup screenshots).
+  If you add a desktop-only asset, guard its reference with `__ANDROID_BUILD__`
+  and the pruner handles the rest; `snooze.png` stays because Android uses it.

--- a/src/app.js
+++ b/src/app.js
@@ -13,23 +13,8 @@ import iconBraveUrl from './images/icon-brave.svg';
 import iconEdgeUrl from './images/icon-edge.svg';
 import iconFirefoxUrl from './images/icon-firefox.svg';
 import iconSafariUrl from './images/icon-safari.svg';
-import screenshotChromeStep1 from './images/toggle-chrome-incognito-windows-1.png';
-import screenshotChromeStep2 from './images/toggle-chrome-incognito-windows-2.png';
-import screenshotEdgeStep1 from './images/toggle-edge-incognito-windows-1.png';
-import screenshotEdgeStep2 from './images/toggle-edge-incognito-windows-2.png';
-import screenshotFirefoxStep1 from './images/toggle-firefox-private-windows-1.png';
-import screenshotFirefoxStep2 from './images/toggle-firefox-private-windows-2.png';
-import screenshotSafariStep1 from './images/mac-extension-settings-1.png';
-import screenshotSafariStep2 from './images/mac-extension-settings-2.png';
-import screenshotAutomationSettings from './images/automation-settings.png';
 import snoozeIconUrl from './images/snooze.png';
 import welcomeDemoVideoUrl from './reddblock-video.mp4';
-import {
-    resolveReleaseNotesForVersion,
-    renderReleaseNotesHtml,
-    releaseNotesHasContent,
-    filterReleaseNotesForPlatform,
-} from './changelog.js';
 // Compatibility layer wrapping Tauri APIs — extracted to tauri-api.js
 import { tauriAPI, openUrl } from './tauri-api.js';
 import { state, appState } from './state.js';
@@ -2838,9 +2823,16 @@ export function applyWelcomeOnboardingLanguage() {
 
     syncWelcomeDemoFullscreenLabel();
 
-    const demoVideo = document.getElementById('welcome-demo-video');
-    if (demoVideo && !demoVideo.src) {
-        demoVideo.src = welcomeDemoVideoUrl;
+    // The welcome demo panel (#welcome-demo-panel, which contains
+    // #welcome-demo-video) is stripped from the Android DOM by
+    // stripNonAndroidUi, so the element never exists there. Guarding the only
+    // reference to welcomeDemoVideoUrl with the compile-time literal lets
+    // Rollup drop the ~1.8 MB reddblock-video.mp4 from the Android bundle.
+    if (!__ANDROID_BUILD__) {
+        const demoVideo = document.getElementById('welcome-demo-video');
+        if (demoVideo && !demoVideo.src) {
+            demoVideo.src = welcomeDemoVideoUrl;
+        }
     }
 
     const continueBtn = document.getElementById('welcome-onboarding-continue-btn');

--- a/src/enforcement.js
+++ b/src/enforcement.js
@@ -272,6 +272,7 @@ export function hideSafariFdaOnboardingUi() {
 
 /** Safari FDA onboarding — same layout/copy pattern as the EULA screen. */
 export function applySafariFdaOnboardingLanguage() {
+    if (__ANDROID_BUILD__) return;
     const shield = document.getElementById('fda-onboarding-shield-logo');
     if (shield) {
         shield.src = logoReddShieldUrl;

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,6 +41,12 @@
     --redd-teal-hover: #21806f;
     --redd-teal-soft: #e5f5f3;
     --redd-teal-soft-border: color-mix(in srgb, var(--redd-teal) 20%, transparent);
+    /* Text sitting on a --redd-teal-soft surface. Much darker than
+       --redd-teal-hover: mid-green on the pale mint fill reads as washed-out
+       even where it technically clears AA (the hover teal is only ~4.27:1).
+       This lands at ~7.2:1 — comfortably readable while still teal, not black.
+       Dark theme keeps its lifted teal (see body.dark-mode). */
+    --redd-teal-on-soft: #155a4b;
     --schedule-pending-bg: rgba(42, 157, 143, 0.08);
     --schedule-pending-border: rgba(42, 157, 143, 0.35);
     --redd-blue: #4a90e2;
@@ -155,6 +161,9 @@ body.dark-mode{
     --redd-teal-hover: #4ec0b0;
     --redd-teal-soft: rgba(57, 158, 144, 0.16);
     --redd-teal-soft-border: color-mix(in srgb, var(--redd-teal) 20%, transparent);
+    /* On dark, teal-soft is a translucent fill over the dark panel, so the
+       lifted teal already has ample contrast — keep it. */
+    --redd-teal-on-soft: #4ec0b0;
     --schedule-pending-bg: rgba(57, 158, 144, 0.12);
     --schedule-pending-border: rgba(57, 158, 144, 0.35);
     --redd-blue: #6aa9ea;
@@ -4725,6 +4734,13 @@ body.dark-mode .day-row.weekend{
     font-weight: 700;
     letter-spacing: 0.02em;
     line-height: 1.2;
+    /* This is a white-text pill. When the focus space has a custom colour,
+       applyRoomChipTint() overrides this background with a darkened accent;
+       but an uncoloured space (no tint) would otherwise inherit the pale
+       --redd-teal-soft fill from .start-confirm-room-chip, leaving white text
+       on pale mint (invisible). Default to a solid dark teal (~5.7:1 on white
+       text) so the untinted chip stays legible in both themes. */
+    background: #1a7361;
     color: #fff;
     pointer-events: none;
     white-space: nowrap;
@@ -11826,7 +11842,7 @@ body.handset-device #start-schedule-confirm-modal .start-confirm-header-room h3{
     line-height: 1.3;
     background: var(--redd-teal-soft);
     border: 1px solid var(--redd-teal-soft-border);
-    color: var(--redd-teal-hover);
+    color: var(--redd-teal-on-soft);
 }
 
 .start-confirm-room-chip-emoji{

--- a/src/update-banner.js
+++ b/src/update-banner.js
@@ -267,8 +267,13 @@ export async function showUpdateBanner(latestVersion, currentVersion = '', { pkg
     scheduleUpdateBannerLayout();
 }
 
-// Check if a newer app version is available and show update banner
+// Check if a newer app version is available and show update banner.
+// Desktop-only: Android/iOS update via their app stores. The compile-time
+// guard makes this a no-op on Android and lets Rollup drop the transitive
+// update-banner UI chain — including changelog.js and the bundled
+// changelog.md (~57 KB of otherwise-unreachable startup parse).
 export async function checkForAppUpdate() {
+    if (__ANDROID_BUILD__) return;
     if (await resolveMicrosoftStorePackage()) {
         return;
     }

--- a/vite.config.js
+++ b/vite.config.js
@@ -215,11 +215,50 @@ const purgeAndroidCss = (enabled) => ({
     },
 });
 
+// Vite emits an asset file for every static `import url from './x.png'` even
+// when tree-shaking later drops the binding — the emit happens in the asset
+// plugin's transform, before dead-code elimination runs. On Android the
+// `__ANDROID_BUILD__` guards strip the desktop-only code that referenced those
+// URLs (browser-setup screenshots in enforcement.js, the welcome demo video in
+// app.js), but the multi-MB media files are still emitted and shipped in the
+// APK, referenced by zero chunks. This prunes any image/video asset whose
+// hashed fileName appears in no emitted JS chunk or stylesheet.
+//
+// Safe because a real reference to a hashed asset can only reach a chunk/CSS
+// via the import binding Vite rewrites — there is no static <img>/<video> in
+// index.html pointing at these (the sole static media ref is the public
+// reddblock-icon.svg, which isn't bundle-hashed and isn't a prunable type).
+const pruneOrphanAndroidAssets = (enabled) => ({
+    name: 'prune-orphan-android-assets',
+    apply: 'build',
+    generateBundle(_options, bundle) {
+        if (!enabled) return;
+        const PRUNABLE = /\.(png|jpe?g|gif|webp|mp4|webm|mov)$/i;
+        const assetText = (source) =>
+            typeof source === 'string' ? source : Buffer.from(source).toString('utf8');
+        const haystack = Object.values(bundle)
+            .map((file) => {
+                if (file.type === 'chunk') return file.code;
+                if (file.type === 'asset' && !PRUNABLE.test(file.fileName)) {
+                    return assetText(file.source);
+                }
+                return '';
+            })
+            .join('\n');
+        for (const file of Object.values(bundle)) {
+            if (file.type !== 'asset' || !PRUNABLE.test(file.fileName)) continue;
+            const base = file.fileName.split('/').pop();
+            if (!haystack.includes(base)) delete bundle[file.fileName];
+        }
+    },
+});
+
 export default defineConfig(async ({ mode }) => ({
     plugins: [
         stripDevTestScripts(),
         stripNonAndroidUi(mode === 'android'),
         purgeAndroidCss(mode === 'android'),
+        pruneOrphanAndroidAssets(mode === 'android'),
         // Bundle analysis: `ANALYZE=1 npm run vite:build:android` writes
         // dist/stats.html (treemap of what actually ships). Dev-only; no
         // effect on the shipped bundle. Loaded via dynamic import because


### PR DESCRIPTION
## Summary

Two related pieces of Android polish, in two commits.

### 1. Bundle slimming (`9e73bf4`)
Extends the existing `__ANDROID_BUILD__` compile-time gating to reclaim weight still shipping to Android:

- **Gate `checkForAppUpdate()`** (already runtime desktop-only) so Rollup drops the transitive update-banner UI chain — including `changelog.js` and the bundled `changelog.md` (~52 KB of otherwise-unreachable startup parse).
- **Guard the welcome demo video** reference and the missing guard on `applySafariFdaOnboardingLanguage`; remove dead screenshot/changelog imports from `app.js`.
- **New `pruneOrphanAndroidAssets` Vite plugin.** Vite emits an asset file for every static `import` even when tree-shaking drops the binding, so DCE'd desktop-only media was left orphaned in the APK. The plugin deletes image/video assets referenced by zero chunks/CSS on Android — recovering ~3.3 MB (welcome video + browser-setup screenshots).

**Net on Android:** ~3.3 MB smaller APK, ~52 KB less startup JS. Desktop build unaffected (all assets + changelog retained).

### 2. Contrast fix (`798e05d`)
Two teal focus-space name chips didn't read on their pale-mint fill:

- **Scheduler "entering" chip** — a white-text pill that, for an uncoloured focus space (no `applyRoomChipTint` background), inherited the pale `--redd-teal-soft` fill → white on pale mint, effectively invisible (e.g. the LinkedIn space). Now defaults to a solid dark teal (~5.7:1 with white); a custom colour still overrides via the JS tint.
- **Confirm/stop-modal chip** — used `--redd-teal-hover` text on `--redd-teal-soft` (~4.27:1, below AA). Added a theme-aware `--redd-teal-on-soft` token (~7.2:1 light; dark keeps its lifted teal).

## Testing
- `vite build` (desktop) and `vite build --mode android` both pass; verified desktop retains all media + changelog while Android drops only the intended assets.
- Built and smoke-tested the debug APK on a **Pixel 8**: onboarding, focus-spaces list, and settings all render correctly with no JS errors; APK confirmed to contain no desktop-only media.
- Confirmed both chip fixes render legibly on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)