### PR TITLE
Reduce desktop enforcement CPU/battery cost

### DIFF
--- a/src-tauri/examples/test_watcher.rs
+++ b/src-tauri/examples/test_watcher.rs
@@ -19,7 +19,7 @@ fn main() {
     }
 
     let h = redd_block_lib::app_watcher::start(None);
-    h.set_apps(names);
+    h.set_apps(names.clone(), names);
     std::thread::sleep(std::time::Duration::from_secs(3));
     h.stop();
 }

--- a/src-tauri/src/app_watcher.rs
+++ b/src-tauri/src/app_watcher.rs
@@ -43,7 +43,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
@@ -63,6 +63,69 @@ const POLL_INTERVAL: Duration = Duration::from_millis(2000);
 /// Faster cadence while at least one PID is mid-countdown (PreQuit /
 /// PostQuit) so the warning overlay and grace timers stay responsive.
 const POLL_INTERVAL_ACTIVE: Duration = Duration::from_millis(1000);
+/// Safety-net cadence when NSWorkspace launch/activation events are
+/// driving wakeups (macOS). Events cover the normal cases — a blocked
+/// app launching, a non-allowed app coming frontmost — within
+/// milliseconds; this slow sweep only catches what AppKit can't see
+/// (raw binaries exec'd outside LaunchServices). Never used while a
+/// countdown is in flight.
+const EVENTED_SAFETY_NET: Duration = Duration::from_secs(15);
+
+/// Wake handle shared with `workspace_events` (macOS) and `set_policy`:
+/// flag + condvar so a wake that lands mid-sweep is never lost.
+type WakePair = (Mutex<bool>, Condvar);
+
+/// True when NSWorkspace events are installed and can be trusted to wake
+/// the sweep loop; false on Windows and whenever install didn't run —
+/// callers then keep the legacy polling cadences.
+fn workspace_events_active() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        crate::workspace_events::events_active()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// Raise the wake flag and notify — from `set_policy`, `stop`, and (on
+/// macOS) NSWorkspace launch/activation/screen-wake notifications.
+fn notify_wake(wake: &WakePair) {
+    let (flag, cvar) = wake;
+    if let Ok(mut raised) = flag.lock() {
+        *raised = true;
+    }
+    cvar.notify_all();
+}
+
+/// Sleep until `timeout` elapses or the wake flag is raised, consuming
+/// the flag. Spurious sweeps are harmless — sweeps are idempotent.
+fn wait_for_wake(wake: &WakePair, timeout: Duration) {
+    let (flag, cvar) = wake;
+    let Ok(mut raised) = flag.lock() else {
+        std::thread::sleep(timeout);
+        return;
+    };
+    let deadline = Instant::now() + timeout;
+    while !*raised {
+        let now = Instant::now();
+        if now >= deadline {
+            break;
+        }
+        match cvar.wait_timeout(raised, deadline - now) {
+            Ok((guard, wait_result)) => {
+                raised = guard;
+                if wait_result.timed_out() {
+                    break;
+                }
+            }
+            Err(_) => return,
+        }
+    }
+    *raised = false;
+}
+
 /// After the user clicks "Let's go!", how long they get to save +
 /// manually quit before the watcher sends the polite Cmd-Q.
 const PREQUIT_DURATION: Duration = Duration::from_secs(30);
@@ -159,6 +222,7 @@ pub struct Handle {
     allowlist_warn_pending: Arc<AtomicBool>,
     pending_warning_apps: PendingWarningApps,
     stop: Arc<AtomicBool>,
+    wake: Arc<WakePair>,
     join: Mutex<Option<std::thread::JoinHandle<()>>>,
 }
 
@@ -172,43 +236,57 @@ impl Handle {
         allowlist_active: bool,
         allowlist_newly_started: bool,
     ) {
-        log::info!(
-            "app_watcher::set_policy: {} blocked, {} newly blocked, {} allowed, allowlist_active={allowlist_active}",
-            blocked.len(),
-            newly_added_blocked.len(),
-            allowed.len(),
-        );
+        // Track whether anything actually changed. The disk-sync loop
+        // calls this every 2 s with an unchanged policy in steady state;
+        // only real transitions may wake the sweep thread (and produce a
+        // log line), otherwise the evented safety-net cadence would
+        // degrade right back into 2 s polling.
+        let mut changed = false;
+
+        let new_blocked: HashSet<String> =
+            blocked.into_iter().filter(|n| !is_protected(n)).collect();
+        let new_allowed: HashSet<String> =
+            allowed.into_iter().filter(|n| !is_protected(n)).collect();
+
         if let Ok(mut w) = self.apps.write() {
-            w.clear();
-            for n in blocked {
-                if is_protected(&n) {
-                    continue;
-                }
-                w.insert(n);
+            if *w != new_blocked {
+                changed = true;
+                *w = new_blocked;
             }
         }
         if let Ok(mut w) = self.allowed_apps.write() {
-            w.clear();
-            for n in allowed {
-                if is_protected(&n) {
-                    continue;
-                }
-                w.insert(n);
+            if *w != new_allowed {
+                changed = true;
+                *w = new_allowed;
             }
         }
-        self.allowlist_active
-            .store(allowlist_active, Ordering::SeqCst);
+        if self
+            .allowlist_active
+            .swap(allowlist_active, Ordering::SeqCst)
+            != allowlist_active
+        {
+            changed = true;
+        }
         if allowlist_newly_started {
             self.allowlist_warn_pending.store(true, Ordering::SeqCst);
+            changed = true;
         }
         if !newly_added_blocked.is_empty() {
             if let Ok(mut p) = self.pending_warning_apps.lock() {
                 for n in newly_added_blocked {
                     if !is_protected(&n) {
+                        changed = true;
                         p.insert(n);
                     }
                 }
             }
+        }
+
+        if changed {
+            log::info!(
+                "app_watcher::set_policy: policy changed (allowlist_active={allowlist_active}); waking sweep"
+            );
+            notify_wake(&self.wake);
         }
     }
 
@@ -219,6 +297,9 @@ impl Handle {
 
     pub fn stop(&self) {
         self.stop.store(true, Ordering::SeqCst);
+        // Wake the sweep thread so the join doesn't block for a full
+        // safety-net interval.
+        notify_wake(&self.wake);
         if let Ok(mut slot) = self.join.lock() {
             if let Some(j) = slot.take() {
                 let _ = j.join();
@@ -276,12 +357,19 @@ pub fn start(app: Option<AppHandle>) -> Handle {
     let allowlist_warn_pending = Arc::new(AtomicBool::new(false));
     let pending_warning_apps: PendingWarningApps = Arc::new(Mutex::new(HashSet::new()));
     let stop = Arc::new(AtomicBool::new(false));
+    let wake: Arc<WakePair> = Arc::new((Mutex::new(false), Condvar::new()));
+    // App launches / activations / screen wakes trip the same condvar
+    // the sweep loop sleeps on, so the evented safety-net cadence stays
+    // as responsive as the old 1-2 s polling.
+    #[cfg(target_os = "macos")]
+    crate::workspace_events::add_waker(wake.clone());
     let apps_for_thread = apps.clone();
     let allowed_for_thread = allowed_apps.clone();
     let allowlist_active_for_thread = allowlist_active.clone();
     let allowlist_warn_for_thread = allowlist_warn_pending.clone();
     let pending_for_thread = pending_warning_apps.clone();
     let stop_for_thread = stop.clone();
+    let wake_for_thread = wake.clone();
     let join = std::thread::spawn(move || {
         run(
             app,
@@ -291,6 +379,7 @@ pub fn start(app: Option<AppHandle>) -> Handle {
             allowlist_warn_for_thread,
             pending_for_thread,
             stop_for_thread,
+            wake_for_thread,
         )
     });
     Handle {
@@ -300,6 +389,7 @@ pub fn start(app: Option<AppHandle>) -> Handle {
         allowlist_warn_pending,
         pending_warning_apps,
         stop,
+        wake,
         join: Mutex::new(Some(join)),
     }
 }
@@ -490,6 +580,7 @@ fn run(
     allowlist_warn_pending: Arc<AtomicBool>,
     pending_warning_apps: PendingWarningApps,
     stop: Arc<AtomicBool>,
+    wake: Arc<WakePair>,
 ) {
     let mut entries: HashMap<sysinfo::Pid, PidEntry> = HashMap::new();
     let mut sys = sysinfo::System::new();
@@ -506,17 +597,27 @@ fn run(
         );
         // Poll fast while a countdown is in flight, or while an allowlist
         // block-start sweep is pending so visible apps behind ReDD Blocker
-        // are caught within ~500ms instead of the 2s idle cadence.
+        // are caught within ~500ms instead of the idle cadence.
+        //
+        // Idle cadence: with NSWorkspace events active (macOS), app
+        // launches / activations / policy changes wake the condvar
+        // directly, so the timed sweep is only a safety net for
+        // processes AppKit doesn't announce — it runs at
+        // EVENTED_SAFETY_NET instead of 1-2 s. Without events (Windows,
+        // or install failure) the legacy polling cadences apply.
+        let evented = workspace_events_active();
         let interval = if !entries.is_empty() {
             POLL_INTERVAL_ACTIVE
         } else if allowlist_warn_pending.load(Ordering::SeqCst) {
             Duration::from_millis(500)
+        } else if evented {
+            EVENTED_SAFETY_NET
         } else if allowlist_active.load(Ordering::SeqCst) {
             POLL_INTERVAL_ACTIVE
         } else {
             POLL_INTERVAL
         };
-        std::thread::sleep(interval);
+        wait_for_wake(&wake, interval);
     }
     // On stop: clear any in-flight warnings so the UI doesn't keep
     // showing a stale modal after the watcher's gone. Mid-block PIDs
@@ -538,6 +639,7 @@ fn run(
     _allowlist_warn_pending: Arc<AtomicBool>,
     _pending_warning_apps: PendingWarningApps,
     _stop: Arc<AtomicBool>,
+    _wake: Arc<WakePair>,
 ) {
     // Linux has no in-process watcher; blocking apps would need a
     // distro-specific approach (e.g. cgroup freezer) — out of scope.

--- a/src-tauri/src/blocking_method.rs
+++ b/src-tauri/src/blocking_method.rs
@@ -41,14 +41,13 @@ impl Method {
 }
 
 /// Read `settings.blockingMethods` from the canonical data file.
+/// Served from the shared mtime-keyed parse cache — the Automation
+/// watcher calls this once per running browser on every 1 s tick.
 pub fn read_map_from_path(path: &Path) -> HashMap<String, String> {
-    let Ok(raw) = std::fs::read_to_string(path) else {
-        return HashMap::new();
-    };
-    let Ok(data) = serde_json::from_str::<Value>(&raw) else {
-        return HashMap::new();
-    };
-    read_map_from_value(&data)
+    match crate::data_cache::read(path) {
+        Some(data) => read_map_from_value(&data),
+        None => HashMap::new(),
+    }
 }
 
 pub fn read_map(app: &AppHandle) -> HashMap<String, String> {

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -418,6 +418,12 @@ pub(crate) fn write_data_file_atomic(
 
     if result.is_err() {
         let _ = fs::remove_file(&tmp);
+    } else {
+        // Drop the shared parse cache so the enforcement loops re-read
+        // this write even if it landed within the filesystem's
+        // timestamp granularity (see data_cache.rs).
+        #[cfg(not(any(target_os = "ios", target_os = "android")))]
+        crate::data_cache::invalidate(path);
     }
     result
 }

--- a/src-tauri/src/data_cache.rs
+++ b/src-tauri/src/data_cache.rs
@@ -1,0 +1,122 @@
+//! Shared parse cache for the canonical data file.
+//!
+//! The enforcement loops re-derive state from `redd-block-data.json` on
+//! every tick — the Automation watcher every 1 s (plus one
+//! `blockingMethods` lookup per running browser), the app-watcher sync
+//! loop every 2 s (twice: blocked + allowed apps), and the enforcer
+//! every 5 s (up to three separate reads). That added up to several
+//! full disk-read + JSON-parse round-trips per second in steady state.
+//!
+//! This module caches the *parsed* `serde_json::Value` keyed on the
+//! file's (mtime, len). Derivations stay live — they depend on `now()`
+//! — but the parse only happens when the file actually changed. The
+//! file is only ever replaced via atomic rename
+//! (`write_data_file_atomic`), which always produces a fresh mtime, so
+//! the (mtime, len) key is a reliable change signal even for writes
+//! from other processes (the browser-spawned native host). Same-process
+//! writers additionally call [`invalidate`] so a rewrite within the
+//! filesystem's timestamp granularity can't serve a stale snapshot.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::SystemTime;
+
+struct Entry {
+    mtime: SystemTime,
+    len: u64,
+    value: Arc<serde_json::Value>,
+}
+
+static CACHE: OnceLock<Mutex<HashMap<PathBuf, Entry>>> = OnceLock::new();
+
+fn cache() -> &'static Mutex<HashMap<PathBuf, Entry>> {
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Parsed snapshot of the JSON file at `path`, re-read only when the
+/// file's (mtime, len) changed since the last call. Returns `None` when
+/// the file is missing, unreadable, or not valid JSON — the same cases
+/// where callers previously bailed to their empty defaults.
+pub fn read(path: &Path) -> Option<Arc<serde_json::Value>> {
+    let meta = std::fs::metadata(path).ok()?;
+    let mtime = meta.modified().ok()?;
+    let len = meta.len();
+
+    if let Ok(guard) = cache().lock() {
+        if let Some(e) = guard.get(path) {
+            if e.mtime == mtime && e.len == len {
+                return Some(e.value.clone());
+            }
+        }
+    }
+
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let value = Arc::new(value);
+    if let Ok(mut guard) = cache().lock() {
+        guard.insert(
+            path.to_path_buf(),
+            Entry {
+                mtime,
+                len,
+                value: value.clone(),
+            },
+        );
+    }
+    Some(value)
+}
+
+/// Drop the cached snapshot for `path`. Called after every same-process
+/// write so the next read re-parses even if the rewrite landed within
+/// the filesystem's timestamp granularity.
+pub fn invalidate(path: &Path) {
+    if let Ok(mut guard) = cache().lock() {
+        guard.remove(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("redd-data-cache-test-{name}-{}", std::process::id()))
+    }
+
+    #[test]
+    fn returns_parsed_json_and_caches_by_identity() {
+        let path = temp_path("basic");
+        std::fs::write(&path, serde_json::to_vec(&json!({"a": 1})).unwrap()).unwrap();
+
+        let first = read(&path).expect("first read");
+        let second = read(&path).expect("second read");
+        assert!(Arc::ptr_eq(&first, &second), "unchanged file must serve the cached Arc");
+        assert_eq!(first.get("a").and_then(|v| v.as_i64()), Some(1));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn picks_up_rewrites() {
+        let path = temp_path("rewrite");
+        std::fs::write(&path, serde_json::to_vec(&json!({"a": 1})).unwrap()).unwrap();
+        let first = read(&path).expect("first read");
+        assert_eq!(first.get("a").and_then(|v| v.as_i64()), Some(1));
+
+        // Different length guarantees a key change even if the two
+        // writes land within the filesystem's timestamp granularity.
+        std::fs::write(&path, serde_json::to_vec(&json!({"a": 22222})).unwrap()).unwrap();
+        invalidate(&path);
+        let second = read(&path).expect("second read");
+        assert_eq!(second.get("a").and_then(|v| v.as_i64()), Some(22222));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        assert!(read(&temp_path("missing-never-created")).is_none());
+    }
+}

--- a/src-tauri/src/enforcer.rs
+++ b/src-tauri/src/enforcer.rs
@@ -69,13 +69,12 @@ fn enforcement_enabled(app: &AppHandle) -> bool {
         Some(p) => p,
         None => return false,
     };
-    let data: serde_json::Value = std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
-        .unwrap_or(serde_json::Value::Null);
-    data.get("settings")
-        .and_then(|s| s.get("enforcementEnabled"))
-        .and_then(|v| v.as_bool())
+    crate::data_cache::read(&path)
+        .and_then(|data| {
+            data.get("settings")
+                .and_then(|s| s.get("enforcementEnabled"))
+                .and_then(|v| v.as_bool())
+        })
         .unwrap_or(false)
 }
 
@@ -91,8 +90,7 @@ pub const GRACE_MAX_SECS: u64 = 300;
 
 fn current_grace(app: &AppHandle) -> Duration {
     let secs = crate::commands::canonical_data_path(app)
-        .and_then(|p| std::fs::read_to_string(&p).ok())
-        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|p| crate::data_cache::read(&p))
         .and_then(|v| {
             v.get("settings")
                 .and_then(|s| s.get("extensionGraceSeconds"))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,6 +103,8 @@ pub mod app_watcher;
 pub mod app_group;
 #[cfg(target_os = "macos")]
 pub mod window_inventory;
+#[cfg(target_os = "macos")]
+pub mod workspace_events;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub mod enforcer;
 // JOMO-style website blocking via macOS Automation (Apple Events) — the
@@ -650,6 +652,13 @@ pub fn run() {
             // browser if the user doesn't fix it within the grace
             // window — that's the whole point of the migration, so
             // there's no reason to gate it behind a frontend opt-in.
+            // NSWorkspace notification bridge: app launch/activation +
+            // screen sleep/wake events that let the app watcher and the
+            // Automation watcher idle instead of polling. Must run on
+            // the main thread, before the watchers start.
+            #[cfg(target_os = "macos")]
+            workspace_events::install();
+
             #[cfg(not(any(target_os = "ios", target_os = "android")))]
             {
                 commands::app_blocking::register(app);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,8 @@ pub mod enforcer;
 #[cfg(target_os = "macos")]
 pub mod web_automation;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
+pub mod data_cache;
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub mod native_host;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub mod native_host_install;

--- a/src-tauri/src/native_host.rs
+++ b/src-tauri/src/native_host.rs
@@ -274,13 +274,12 @@ pub fn blocklist_mode_is_allowlist(mode: &str) -> bool {
 /// ascending by `endsAt`. This is the single source of truth for what the
 /// extension sees on every frame.
 pub fn derive_payload(data_path: &std::path::Path) -> (Vec<String>, Vec<BlockInfo>) {
-    let raw = match std::fs::read_to_string(data_path) {
-        Ok(s) => s,
-        Err(_) => return (vec![], vec![]),
-    };
-    let data: Value = match serde_json::from_str(&raw) {
-        Ok(v) => v,
-        Err(_) => return (vec![], vec![]),
+    // mtime-keyed parse cache: this runs on every watcher/enforcer tick,
+    // but the file only changes on user actions. The derivation below
+    // stays live (it depends on now()); only the parse is cached.
+    let data = match crate::data_cache::read(data_path) {
+        Some(d) => d,
+        None => return (vec![], vec![]),
     };
     let now_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -413,13 +412,9 @@ pub fn derive_blocklist(data_path: &std::path::Path) -> Vec<String> {
 /// segments. App-only schedules (no websites) still contribute here
 /// even though `derive_payload` only surfaces domains.
 pub fn derive_blocked_apps(data_path: &std::path::Path) -> Vec<String> {
-    let raw = match std::fs::read_to_string(data_path) {
-        Ok(s) => s,
-        Err(_) => return vec![],
-    };
-    let data: Value = match serde_json::from_str(&raw) {
-        Ok(v) => v,
-        Err(_) => return vec![],
+    let data = match crate::data_cache::read(data_path) {
+        Some(d) => d,
+        None => return vec![],
     };
     let now_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -505,13 +500,9 @@ pub fn derive_blocked_apps(data_path: &std::path::Path) -> Vec<String> {
 /// Mirrors the frontend's `collectManualAllowedApps` /
 /// `collectScheduleAllowedApps` merge.
 pub fn derive_allowed_apps(data_path: &std::path::Path) -> Vec<String> {
-    let raw = match std::fs::read_to_string(data_path) {
-        Ok(s) => s,
-        Err(_) => return vec![],
-    };
-    let data: Value = match serde_json::from_str(&raw) {
-        Ok(v) => v,
-        Err(_) => return vec![],
+    let data = match crate::data_cache::read(data_path) {
+        Some(d) => d,
+        None => return vec![],
     };
     let now_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/src-tauri/src/web_automation.rs
+++ b/src-tauri/src/web_automation.rs
@@ -44,6 +44,15 @@ use crate::native_host::{self, BlockInfo};
 /// send Apple Events to browsers `sysinfo` reports as alive.
 const TICK: Duration = Duration::from_millis(1000);
 
+/// Cadence for browsers that are running but NOT frontmost while
+/// workspace events are active. Only the frontmost browser is scripted
+/// every tick — the user can't see a background browser's tabs, and a
+/// blocked tab parked there is bounced within one tick of the browser
+/// being activated (the activation updates `frontmost_bundle_id`
+/// immediately). The slower full pass still catches background
+/// navigation (media/JS opening a blocked site in a hidden window).
+const BACKGROUND_BROWSER_TICK: Duration = Duration::from_secs(5);
+
 /// Once a browser's Automation permission is denied, stop hammering
 /// osascript every second (each call just returns -1743 until the user
 /// changes System Settings). Re-probe at this cadence so a later grant
@@ -351,13 +360,28 @@ pub fn start(app: AppHandle, block_page_url: String) -> WebAutomationHandle {
         // blocklist. Used to fire exactly one "restore" pass when a
         // block ends, instead of scripting browsers forever while idle.
         let mut had_active_block = false;
+        // When the last full pass (all running browsers, not just the
+        // frontmost one) was scripted — drives BACKGROUND_BROWSER_TICK.
+        let mut last_full_pass: Option<Instant> = None;
         loop {
             std::thread::sleep(TICK);
             let enabled = shared_thread.lock().map(|s| s.enabled).unwrap_or(false);
             if !enabled {
                 continue;
             }
-            tick(&app, &shared_thread, &block_page_url, &mut had_active_block);
+            // Displays off → nobody can see a blocked tab. Skip all
+            // Apple Events (and the data-file stat) until wake; the
+            // first tick after wake redirects/restores as needed.
+            if crate::workspace_events::screen_asleep() {
+                continue;
+            }
+            tick(
+                &app,
+                &shared_thread,
+                &block_page_url,
+                &mut had_active_block,
+                &mut last_full_pass,
+            );
         }
     });
     WebAutomationHandle { shared }
@@ -368,6 +392,7 @@ fn tick(
     shared: &Arc<Mutex<Shared>>,
     block_page_url: &str,
     had_active_block: &mut bool,
+    last_full_pass: &mut Option<Instant>,
 ) {
     let path = match crate::commands::canonical_data_path(app) {
         Some(p) => p,
@@ -382,9 +407,50 @@ fn tick(
     if !blocking_active && !*had_active_block {
         return;
     }
+    // The restore pass must reach every running browser, regardless of
+    // the frontmost-only cadence below — computed before the flag flips.
+    let restore_pass = !blocking_active && *had_active_block;
     *had_active_block = blocking_active;
 
-    let running = running_supported_browsers()
+    // Frontmost-aware cadence. The browser the user is looking at is
+    // scripted every tick; the rest ride BACKGROUND_BROWSER_TICK. When
+    // events aren't installed (or the frontmost app is unknown) every
+    // tick is a full pass — the pre-events behavior.
+    let events = crate::workspace_events::events_active();
+    let frontmost_bid = if events {
+        crate::workspace_events::frontmost_bundle_id()
+    } else {
+        None
+    };
+    let frontmost_browser = frontmost_bid
+        .as_deref()
+        .and_then(|bid| SupportedBrowser::all().into_iter().find(|b| b.bundle_id() == bid));
+    let full_pass = restore_pass
+        || !events
+        || frontmost_bid.is_none()
+        || last_full_pass
+            .map(|t| t.elapsed() >= BACKGROUND_BROWSER_TICK)
+            .unwrap_or(true);
+
+    // Nothing due this tick: the frontmost app isn't an automation
+    // browser and the background cadence hasn't elapsed. Skip even the
+    // process scan.
+    if !full_pass && frontmost_browser.is_none() {
+        return;
+    }
+
+    // Frontmost-only ticks skip the sysinfo process scan entirely — a
+    // frontmost browser is by definition running.
+    let candidates = if full_pass {
+        running_supported_browsers()
+    } else {
+        frontmost_browser.into_iter().collect()
+    };
+    if full_pass {
+        *last_full_pass = Some(Instant::now());
+    }
+
+    let running = candidates
         .into_iter()
         .filter(|browser| {
             let key = match browser {

--- a/src-tauri/src/web_automation.rs
+++ b/src-tauri/src/web_automation.rs
@@ -583,9 +583,16 @@ fn set_perm_inner(
 }
 
 pub fn running_supported_browsers() -> Vec<SupportedBrowser> {
-    use sysinfo::{ProcessesToUpdate, System};
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
     let mut sys = System::new();
-    sys.refresh_processes(ProcessesToUpdate::All, true);
+    // Name matching only — skip the default per-process CPU/memory/disk/
+    // exe/cmdline refresh, which is system-wide work this 1 s tick (and
+    // the UI's permission polling) would otherwise repeat forever.
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing(),
+    );
     let mut out = Vec::new();
     for browser in SupportedBrowser::all() {
         let needle = browser.process_name().to_ascii_lowercase();
@@ -633,6 +640,16 @@ fn read_tabs(browser: SupportedBrowser) -> Result<Vec<Tab>, AutomationError> {
     // it), so `... & tab & ...` would concatenate the literal text "tab"
     // instead of an ASCII-9 separator and the Rust parser would drop every row.
     // Hoisting into `_sep`/`_eol` keeps them as real control characters.
+    //
+    // PERF: `URL of every tab of w` fetches a whole window's tab URLs in
+    // ONE Apple Event; the inner repeat then walks a local list with no
+    // further IPC. The previous per-tab `URL of t` cost one Apple Event
+    // round-trip per tab per tick — with many tabs open, by far the
+    // dominant CPU/battery cost of this watcher, on both sides of the
+    // event. Tab indices are positional in the returned list, matching
+    // the `tab <i> of window <w>` addressing `apply_actions` uses.
+    // Safari reports `missing value` for empty tabs; the `as text`
+    // coercion is wrapped in `try` so those rows degrade to "".
     let script = format!(
         r#"set _sep to tab
 set _eol to linefeed
@@ -643,19 +660,18 @@ if application "{app}" is running then
     repeat with w in windows
       set _wi to _wi + 1
       try
-        set _tabs to tabs of w
+        set _urls to URL of every tab of w
       on error
-        set _tabs to {{}}
+        set _urls to {{}}
       end try
       set _ti to 0
-      repeat with t in _tabs
+      repeat with _u in _urls
         set _ti to _ti + 1
+        set _u_text to ""
         try
-          set _u to URL of t
-        on error
-          set _u to ""
+          set _u_text to _u as text
         end try
-        set _out to _out & _wi & _sep & _ti & _sep & _u & _eol
+        set _out to _out & _wi & _sep & _ti & _sep & _u_text & _eol
       end repeat
     end repeat
     return _out

--- a/src-tauri/src/workspace_events.rs
+++ b/src-tauri/src/workspace_events.rs
@@ -1,0 +1,247 @@
+//! NSWorkspace notification bridge (macOS).
+//!
+//! Turns AppKit's workspace notifications into cheap process-wide state
+//! the enforcement loops can consume without polling:
+//!
+//!   - `didLaunchApplication` / `didActivateApplication` → wake every
+//!     registered watcher condvar, so the app watcher can sit on a slow
+//!     safety-net cadence and still react to a blocked-app launch (or an
+//!     allowlist frontmost change) within milliseconds.
+//!   - `didActivateApplication` also records the frontmost app's bundle
+//!     id, which the Automation watcher uses to script the browser the
+//!     user is actually looking at every tick while backing background
+//!     browsers off to a slower cadence.
+//!   - `screensDidSleep` / `screensDidWake` → a flag the Automation
+//!     watcher checks to stop scripting browsers while the display is
+//!     off (nobody can see a blocked tab; the restore/redirect happens
+//!     on the first tick after wake).
+//!
+//! `install()` must run on the main thread (Tauri's `setup` closure) —
+//! NSWorkspace posts these notifications on the main run loop, which the
+//! Tauri process always pumps. The observer object is intentionally
+//! leaked; it lives for the process lifetime.
+//!
+//! If `install()` is never called (tests, or a future caller ordering
+//! bug) `events_active()` stays false and every consumer falls back to
+//! its legacy polling cadence — event delivery is a power optimization,
+//! never a correctness dependency.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+use cocoa::base::{id, nil};
+use cocoa::foundation::NSString;
+use objc::declare::ClassDecl;
+use objc::runtime::{Object, Sel};
+use objc::{class, msg_send, sel, sel_impl};
+
+/// Shared wake handle: flag + condvar. A watcher sleeps with
+/// `wait_timeout` on the condvar; `wake_all` sets the flag and notifies,
+/// so a wake that races the watcher's sweep is never lost.
+pub type WakePair = (Mutex<bool>, Condvar);
+
+static INSTALLED: AtomicBool = AtomicBool::new(false);
+static EVENTS_ACTIVE: AtomicBool = AtomicBool::new(false);
+static SCREEN_ASLEEP: AtomicBool = AtomicBool::new(false);
+
+static FRONTMOST_BUNDLE: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+static WAKERS: OnceLock<Mutex<Vec<Arc<WakePair>>>> = OnceLock::new();
+
+fn frontmost_bundle() -> &'static Mutex<Option<String>> {
+    FRONTMOST_BUNDLE.get_or_init(|| Mutex::new(None))
+}
+
+fn wakers() -> &'static Mutex<Vec<Arc<WakePair>>> {
+    WAKERS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// True once `install()` has successfully registered the observers.
+pub fn events_active() -> bool {
+    EVENTS_ACTIVE.load(Ordering::SeqCst)
+}
+
+/// True while the displays are asleep (per NSWorkspace screen
+/// notifications). False when events aren't installed.
+pub fn screen_asleep() -> bool {
+    SCREEN_ASLEEP.load(Ordering::SeqCst)
+}
+
+/// Bundle id of the frontmost application, as of the last activation
+/// notification (seeded once at install). `None` when unknown — callers
+/// must treat unknown as "poll everything", never as "poll nothing".
+pub fn frontmost_bundle_id() -> Option<String> {
+    frontmost_bundle().lock().ok().and_then(|g| g.clone())
+}
+
+/// Register a watcher's wake handle. Every app launch/activation and
+/// screen wake sets the flag and notifies the condvar.
+pub fn add_waker(w: Arc<WakePair>) {
+    if let Ok(mut g) = wakers().lock() {
+        g.push(w);
+    }
+}
+
+pub fn wake_all() {
+    let Ok(g) = wakers().lock() else {
+        return;
+    };
+    for w in g.iter() {
+        let (flag, cvar) = &**w;
+        if let Ok(mut f) = flag.lock() {
+            *f = true;
+        }
+        cvar.notify_all();
+    }
+}
+
+fn set_frontmost_from_notification(notif: id) {
+    unsafe {
+        let user_info: id = msg_send![notif, userInfo];
+        if user_info.is_null() {
+            return;
+        }
+        let key = NSString::alloc(nil).init_str("NSWorkspaceApplicationKey");
+        let app_obj: id = msg_send![user_info, objectForKey: key];
+        let _: () = msg_send![key, release];
+        if app_obj.is_null() {
+            return;
+        }
+        let bundle = nsstring_property(app_obj, sel!(bundleIdentifier));
+        if let Ok(mut g) = frontmost_bundle().lock() {
+            *g = bundle;
+        }
+    }
+}
+
+unsafe fn nsstring_property(obj: id, selector: Sel) -> Option<String> {
+    let s: id = msg_send![obj, performSelector: selector];
+    if s.is_null() {
+        return None;
+    }
+    let c: *const std::os::raw::c_char = msg_send![s, UTF8String];
+    if c.is_null() {
+        return None;
+    }
+    Some(std::ffi::CStr::from_ptr(c).to_string_lossy().into_owned())
+}
+
+extern "C" fn app_launched(_this: &Object, _sel: Sel, _notif: id) {
+    wake_all();
+}
+
+extern "C" fn app_activated(_this: &Object, _sel: Sel, notif: id) {
+    set_frontmost_from_notification(notif);
+    wake_all();
+}
+
+extern "C" fn screens_slept(_this: &Object, _sel: Sel, _notif: id) {
+    SCREEN_ASLEEP.store(true, Ordering::SeqCst);
+}
+
+extern "C" fn screens_woke(_this: &Object, _sel: Sel, _notif: id) {
+    SCREEN_ASLEEP.store(false, Ordering::SeqCst);
+    wake_all();
+}
+
+/// Register the NSWorkspace observers. Idempotent; main thread only.
+pub fn install() {
+    if INSTALLED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let Some(mut decl) = ClassDecl::new("ReddWorkspaceObserver", class!(NSObject)) else {
+        log::warn!("workspace_events: observer class already registered; events disabled");
+        return;
+    };
+    unsafe {
+        decl.add_method(
+            sel!(reddAppLaunched:),
+            app_launched as extern "C" fn(&Object, Sel, id),
+        );
+        decl.add_method(
+            sel!(reddAppActivated:),
+            app_activated as extern "C" fn(&Object, Sel, id),
+        );
+        decl.add_method(
+            sel!(reddScreensSlept:),
+            screens_slept as extern "C" fn(&Object, Sel, id),
+        );
+        decl.add_method(
+            sel!(reddScreensWoke:),
+            screens_woke as extern "C" fn(&Object, Sel, id),
+        );
+        let cls = decl.register();
+        // Leaked deliberately: observers must outlive the run loop.
+        let observer: id = msg_send![cls, new];
+        let ws: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+        let nc: id = msg_send![ws, notificationCenter];
+
+        unsafe fn observe(nc: id, observer: id, selector: Sel, name: &str) {
+            let name_ns = NSString::alloc(nil).init_str(name);
+            let _: () = msg_send![nc, addObserver:observer
+                                        selector:selector
+                                            name:name_ns
+                                          object:nil];
+            // `name_ns` is retained by the notification center registration
+            // path as needed; release our +1.
+            let _: () = msg_send![name_ns, release];
+        }
+
+        observe(
+            nc,
+            observer,
+            sel!(reddAppLaunched:),
+            "NSWorkspaceDidLaunchApplicationNotification",
+        );
+        observe(
+            nc,
+            observer,
+            sel!(reddAppActivated:),
+            "NSWorkspaceDidActivateApplicationNotification",
+        );
+        observe(
+            nc,
+            observer,
+            sel!(reddScreensSlept:),
+            "NSWorkspaceScreensDidSleepNotification",
+        );
+        observe(
+            nc,
+            observer,
+            sel!(reddScreensWoke:),
+            "NSWorkspaceScreensDidWakeNotification",
+        );
+
+        // Seed the frontmost app so the Automation watcher has a correct
+        // answer before the first activation notification arrives.
+        let front: id = msg_send![ws, frontmostApplication];
+        if !front.is_null() {
+            let bundle = nsstring_property(front, sel!(bundleIdentifier));
+            if let Ok(mut g) = frontmost_bundle().lock() {
+                *g = bundle;
+            }
+        }
+    }
+    EVENTS_ACTIVE.store(true, Ordering::SeqCst);
+    log::info!("workspace_events: NSWorkspace observers installed");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wake_all_sets_flag_and_notifies() {
+        let pair: Arc<WakePair> = Arc::new((Mutex::new(false), Condvar::new()));
+        add_waker(pair.clone());
+        wake_all();
+        assert!(*pair.0.lock().unwrap(), "wake_all must set the wake flag");
+    }
+
+    #[test]
+    fn events_inactive_without_install() {
+        // Tests never call install(); consumers must see events_active()
+        // false and fall back to their legacy polling cadences.
+        assert!(!events_active());
+        assert!(!screen_asleep());
+    }
+}


### PR DESCRIPTION
## Why

ReDD Blocker's desktop enforcement loops were too hungry on CPU/battery. The cost was concentrated in the steady-state ticks of the Automation watcher (1 s), the app watcher (1–2 s), and the enforcer (5 s).

## Commit 1 — hot-path cost per tick

1. **Per-tab Apple Events.** `read_tabs` now batches with `URL of every tab of w` — one Apple Event per window instead of one round-trip per tab per 1 s tick (40 tabs = 40 IPCs/sec before, serviced on the browser's side too). Tab indices stay positional so the `set URL of tab i of window w` redirect addressing is unchanged; Safari's `missing value` URLs degrade to "" via a `try`-wrapped coercion.
2. **Full-fat process scans.** `running_supported_browsers()` now refreshes process names only (`ProcessRefreshKind::nothing()`) instead of sysinfo's default refresh, which pulled CPU/memory/disk/cmdline/env for every process on the system every second (and on every UI permission poll).
3. **Redundant JSON parsing.** New `data_cache` module: (mtime, len)-keyed cache of the parsed `redd-block-data.json`, shared by `derive_payload` / `derive_blocked_apps` / `derive_allowed_apps`, `blocking_method`, and the enforcer's settings reads (previously ~3–6 disk-read + parse round-trips/sec). Ticks now `stat()` and only re-parse on change; time-dependent derivation still runs live. `write_data_file_atomic` invalidates on same-process writes; cross-process writers (native host) are caught by the mtime change since the file is only ever replaced by atomic rename.
- Incidental: fixes `examples/test_watcher.rs` (broken by an earlier `set_apps` signature change), which was failing `cargo test` compilation.

## Commit 2 — event-driven instead of polling (macOS)

New `workspace_events` module registers NSWorkspace observers (app launch, app activation, screens sleep/wake) on the main run loop and exposes wake condvars, the frontmost bundle id, and a screen-asleep flag. If `install()` never runs, everything falls back to the legacy polling cadences — events are a power optimization, never a correctness dependency.

**App watcher:** sleeps on a condvar woken by NSWorkspace events / policy changes / `stop()`. With events active, idle cadence drops from 1–2 s to a 15 s safety net (only needed for raw binaries exec'd outside LaunchServices — AppKit events cover normal app launches/activations within milliseconds). This also removes the once-per-second `CGWindowListCopyWindowInfo` (WindowServer IPC) during focus-space sessions. Countdown (1 s) and allowlist block-start (500 ms) cadences unchanged. `set_policy` now detects no-op updates so the 2 s disk-sync loop doesn't defeat the safety net (also kills its every-2 s info-log spam). Windows behavior unchanged.

**Automation watcher:** only the frontmost browser is scripted every 1 s; background browsers ride a 5 s full pass (a blocked tab parked in a background browser is bounced within one tick of activation — the activation notification updates the frontmost bundle id first). Frontmost-only ticks skip the sysinfo scan entirely. Ticks skip while displays are asleep; restore passes (block just ended) always reach every running browser.

**Deliberately not done:** in-process NSAppleScript instead of per-tick osascript spawns. The child process is killable on timeout (`OSASCRIPT_TIMEOUT`), which is load-bearing when a browser stalls an Apple Event on the Automation consent dialog; an in-process execute can't be aborted and would wedge the watcher thread while holding the `APPLE_EVENTS` lock. With the frontmost-aware cadence the spawn rate is ~1/s under an active block anyway.

## Net effect

Idle (no block): one file-stat/sec + a 15 s safety-net sweep. Active website block, browser frontmost: one lean scan + ~1 Apple Event per window per second. Active block, browser in background: one small pass every 5 s. Focus-space session: sweeps only on app activations + 15 s safety net, instead of 1 s polling with WindowServer IPC. Screens asleep: near-zero.

## Testing

- `cargo test`: 59 passed (includes new `data_cache` + `workspace_events` tests).
- NSWorkspace bridge verified live with a standalone harness: observer install, frontmost seeding, activation wakeups on real app switches all confirmed.
- Batched AppleScript live-tested against a running Chrome: emits the same `window \t tab \t url` rows the Rust parser expects.
- Still needs before merge: the manual redirect checklist (`scripts/manual-test-checklist.md`) across Safari/Brave/Edge, an app-block + focus-space session on a real machine, and a Windows build check (app watcher signature changes compile-time affect Windows; behavior there is unchanged).