### PR TITLE
Align mobile app picker layout

### DIFF
--- a/src/blocking-platform.js
+++ b/src/blocking-platform.js
@@ -1565,6 +1565,32 @@ export function setupHandsetModalScreens() {
 }
 
 
+function configureMobileBlocklistFields() {
+    // Mobile apps are selected from the platform picker. Keep the text fields
+    // out of the UI and the tab order so app names cannot be entered manually.
+    ['app-input', 'modal-app-input', 'quick-start-app-input'].forEach((id) => {
+        const input = document.getElementById(id);
+        if (!input) return;
+        input.style.display = 'none';
+        input.disabled = true;
+        input.setAttribute('aria-hidden', 'true');
+        input.tabIndex = -1;
+    });
+
+    // Keep desktop's website-first layout, but put apps first in both mobile
+    // entry points. Moving the nodes also keeps accessibility/tab order in
+    // sync with what is shown on screen.
+    [
+        ['blocklist-apps-group', 'blocklist-websites-group'],
+        ['quick-start-apps-group', 'quick-start-websites-group'],
+    ].forEach(([appsId, websitesId]) => {
+        const appsGroup = document.getElementById(appsId);
+        const websitesGroup = document.getElementById(websitesId);
+        if (!appsGroup || !websitesGroup || appsGroup.parentElement !== websitesGroup.parentElement) return;
+        websitesGroup.parentElement.insertBefore(appsGroup, websitesGroup);
+    });
+}
+
 // Detect platform for window controls and iOS
 export function detectPlatform() {
     // Check for iOS (Tauri iOS uses a WKWebView with standard iOS user agent)
@@ -1587,23 +1613,8 @@ export function detectPlatform() {
         // Hide helper-related settings section on iOS
         document.getElementById('helper-settings-section')?.classList.add('hidden');
 
-        // On iOS, app blocking uses Screen Time tokens (not app names).
-        // Hide the text input for apps and show only the picker button.
-        const appInput = document.getElementById('app-input');
-        if (appInput) appInput.style.display = 'none';
-        const modalAppInput = document.getElementById('modal-app-input');
-        if (modalAppInput) modalAppInput.style.display = 'none';
-
-
-
-        // Update hint/tooltip for modal — find via modal-app-input's parent
-        const modalAppGroup = document.querySelector('#modal-app-input')?.closest('.form-group');
-        if (modalAppGroup) {
-            const modalTooltip = modalAppGroup.querySelector('.info-tooltip');
-            if (modalTooltip) modalTooltip.textContent = 'On iOS, apps are selected using Apple\'s Screen Time picker. Tap the button to choose which apps to block.';
-        }
-
-        /* Browse buttons in #blocklist-modal: layout + captions from CSS (body.ios …) and applySettingsLanguage(). */
+        // iOS app blocking uses Screen Time tokens (not app names).
+        configureMobileBlocklistFields();
     } else if (/Android/.test(navigator.userAgent)) {
         state.isAndroid = true;
         document.body.classList.add('android');
@@ -1614,9 +1625,9 @@ export function detectPlatform() {
         document.getElementById('window-controls')?.classList.add('hidden');
         document.querySelector('.title-bar')?.classList.add('hidden');
         document.getElementById('helper-settings-section')?.classList.add('hidden');
-        // Unlike iOS, Android app blocking uses plain package names (same
-        // shape as desktop's process names), so the text input + picker
-        // both stay usable — no UI to hide here.
+        // Android app blocking uses the installed-app picker. Keep package
+        // names out of the manual text-entry path on mobile.
+        configureMobileBlocklistFields();
     } else {
         const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
         if (isMac) {

--- a/src/index.html
+++ b/src/index.html
@@ -1204,7 +1204,7 @@
                     </div>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" id="blocklist-websites-group">
                     <label class="label-with-info">
                         <span id="blocklist-websites-label">Websites to block</span>
                         <span class="info-tooltip-wrapper">
@@ -1276,7 +1276,7 @@
                         reddit.com)</span>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" id="blocklist-apps-group">
                     <label class="label-with-info">
                         <span id="blocklist-apps-label">Apps to block</span>
                         <span class="info-tooltip-wrapper">
@@ -1424,7 +1424,7 @@
                     </div>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" id="quick-start-websites-group">
                     <label class="label-with-info">
                         <span id="quick-start-websites-label">Websites to block</span>
                         <span class="info-tooltip-wrapper">
@@ -1491,7 +1491,7 @@
                         (e.g. reddit.com)</span>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" id="quick-start-apps-group">
                     <label class="label-with-info">
                         <span id="quick-start-apps-label">Apps to block</span>
                         <span class="info-tooltip-wrapper">

--- a/src/styles.css
+++ b/src/styles.css
@@ -11249,8 +11249,11 @@ body.handset-device #blocklist-modal .tags-input-stacked .browse-btn{
     gap: 6px;
 }
 
-/* iOS iPhone: app input is hidden — picker button should span the full input row width. */
-body.ios-phone #blocklist-modal .tags-input-stacked .apps-input-with-button .browse-btn{
+/* iPhone and Android: app input is hidden — picker button spans the full row. */
+body.ios-phone #blocklist-modal .tags-input-stacked .apps-input-with-button .browse-btn,
+body.android #blocklist-modal .tags-input-stacked .apps-input-with-button .browse-btn,
+body.ios-phone #quick-start-modal .tags-input-stacked .apps-input-with-button .browse-btn,
+body.android #quick-start-modal .tags-input-stacked .apps-input-with-button .browse-btn{
     width: 100%;
     max-width: 100%;
     flex: 1 1 auto;


### PR DESCRIPTION
## What changed

- Show Apps to block before Websites to block on iPhone and Android.
- Use picker-only app selection on both mobile platforms by hiding and disabling manual app text inputs.
- Make the picker button span the full row in the focus-space editor and Quick Start.

## Why

Android should use the same mobile interaction pattern as iPhone while continuing to use its installed-app picker.

## Validation

- `node --check src/blocking-platform.js`
- `node --check src/app.js`
- `node --check src/quick-start.js`
- `git diff --check`

A full frontend build was not run because dependencies are not installed in this worktree.
