### PR TITLE
[codex] Fix Firefox add-on URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ flowchart LR
 | Browser | How blocking works | Extension setup |
 |---------|-------------------|-----------------|
 | Safari, Chrome, Brave, Edge | **Automation** (Apple Events) — Digital Habits: Blocker redirects blocked tabs | Digital Habits: Blocker prompts for Automation in System Settings → Privacy & Security → Automation |
-| Firefox | Digital Habits: Focus extension | Install manually from the [Firefox Add-ons store](https://addons.mozilla.org/) — Digital Habits: Blocker does **not** auto-install on macOS |
+| Firefox | Digital Habits: Focus extension | Install manually from the [Digital Habits: Focus Firefox add-on](https://addons.mozilla.org/en-US/firefox/addon/digitalhabits-focus/) — Digital Habits: Blocker does **not** auto-install on macOS |
 
 **Windows**
 

--- a/browser-ext-migration/FORCE_INSTALL_EXTENSIONS.md
+++ b/browser-ext-migration/FORCE_INSTALL_EXTENSIONS.md
@@ -208,7 +208,7 @@ directories anymore — XPIs placed there sit forever doing nothing.
 ```json
 { "policies": { "ExtensionSettings": { "<gecko-id>": {
   "installation_mode": "force_installed",
-  "install_url": "https://addons.mozilla.org/firefox/downloads/latest/reddfocus/latest.xpi"
+  "install_url": "https://addons.mozilla.org/firefox/downloads/latest/digitalhabits-focus/latest.xpi"
 }}}}
 ```
 
@@ -347,7 +347,7 @@ Two options:
   acceptable since we can re-bundle on each Digital Habits: Blocker release.
 
 - **Download on first run** — fetch from
-  `https://addons.mozilla.org/firefox/downloads/latest/reddfocus/latest.xpi`
+  `https://addons.mozilla.org/firefox/downloads/latest/digitalhabits-focus/latest.xpi`
   the first time we install the hint for Firefox. Always current.
   Requires network; slows onboarding.
 

--- a/src-tauri/src/extension_install.rs
+++ b/src-tauri/src/extension_install.rs
@@ -104,7 +104,7 @@ pub const EDGE_UPDATE_URL: &str = CHROMIUM_UPDATE_URL;
 /// AMO URL Firefox fetches the XPI from when the policy is in place.
 /// Always-redirects to the latest signed release.
 pub const FIREFOX_AMO_XPI_URL: &str =
-    "https://addons.mozilla.org/firefox/downloads/latest/reddfocus/latest.xpi";
+    "https://addons.mozilla.org/firefox/downloads/latest/digitalhabits-focus/latest.xpi";
 
 #[derive(Debug, Clone, Copy, Serialize)]
 pub enum BrowserTarget {

--- a/src/enforcement.js
+++ b/src/enforcement.js
@@ -618,7 +618,7 @@ export const BROWSER_STORE_LINKS = {
     chrome: { label: 'Chrome', url: 'https://chromewebstore.google.com/detail/redd-focus-hide-distracti/hhblkhfdjijdinijakbmcpkmdfhoadcd' },
     brave: { label: 'Brave', url: 'https://chromewebstore.google.com/detail/redd-focus-hide-distracti/hhblkhfdjijdinijakbmcpkmdfhoadcd' },
     edge: { label: 'Edge', url: 'https://microsoftedge.microsoft.com/addons/detail/redd-focus-hide-distract/gmjfgjdhnhcegfelcddbdljdffiaepam' },
-    firefox: { label: 'Firefox', url: 'https://addons.mozilla.org/en-US/firefox/addon/reddfocus/' },
+    firefox: { label: 'Firefox', url: 'https://addons.mozilla.org/en-US/firefox/addon/digitalhabits-focus/' },
     safari: { label: 'Safari', url: 'macappstore://apps.apple.com/app/id1660218371' },
 };
 


### PR DESCRIPTION
## Summary

- Update the in-app Firefox add-on link to the current Digital Habits: Focus AMO listing.
- Update Firefox policy installation URLs and the corresponding documentation to use the current AMO download slug.

## Why

The latest app still pointed users and Firefox’s force-install policy at the old `reddfocus` listing, so the add-on link and automatic installation path were stale.

## Validation

- `git diff --check`
- Confirmed no stale `reddfocus` AMO URLs remain in the updated app/docs paths.
- Full build not run; this is a URL-only change.
