### PR TITLE
Fix Android website blocking in Samsung Internet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ There is no CLI test runner. Tests run **inside the app** in dev mode via the de
 - **Tier 1 (logic, instant, no system changes):** start `npm run dev`, then `Cmd+Shift+T` (macOS) / `Ctrl+Shift+T` (Windows), or `runBlockingTests()` in the console. Cases live in `src/blocking-tests.js` (+ helpers in `src/test-utils.js`).
 - **Tier 2 (integration, real command paths, safe `.invalid` domains):** `runIntegrationTests('core')` or `runIntegrationTests('full')` in the console. Cases in `src/integration-tests.js`. Note: Tier 2 asserts the Rust-derived `current_blocking` snapshot — it does **not** prove a browser actually redirects.
 - **Website-enforcement correctness (Automation redirects, extension blocking) is validated manually** — see `scripts/manual-test-checklist.md`.
+- **Android browser URL parsing** has JVM unit tests: `cd src-tauri/gen/android && ./gradlew :tauri-plugin-android-blocker:testDebugUnitTest`. Fixtures in `BrowserUrlParserTest` are raw URL-bar strings dumped from real devices — add one whenever you touch the supported-browser list (details in [testing.md](testing.md)).
 
 ## Architecture essentials
 

--- a/tauri-plugin-android-blocker/android/build.gradle.kts
+++ b/tauri-plugin-android-blocker/android/build.gradle.kts
@@ -36,4 +36,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.work:work-runtime-ktx:2.10.0")
     implementation(project(":tauri-android"))
+    // JVM unit tests for the pure blocking logic (BrowserUrlParser):
+    //   src-tauri/gen/android/gradlew :tauri-plugin-android-blocker:testDebugUnitTest
+    testImplementation("junit:junit:4.13.2")
 }

--- a/tauri-plugin-android-blocker/android/src/main/java/net/kollnig/reddblockandroid/service/BlockerService.kt
+++ b/tauri-plugin-android-blocker/android/src/main/java/net/kollnig/reddblockandroid/service/BlockerService.kt
@@ -144,51 +144,8 @@ class BlockerService : AccessibilityService() {
         return shouldSkip
     }
 
-    /** Maps browser package names to their URL bar view IDs */
-    private val browserUrlViewIds = mapOf(
-        // Firefox variants
-        "org.mozilla.firefox" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
-        "org.mozilla.firefox_beta" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
-        "org.mozilla.fenix" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
-        "org.mozilla.fenix.nightly" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
-        "org.mozilla.focus" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
-        // Chrome / Chromium
-        "com.android.chrome" to listOf("url_bar", "origin", "display_url"),
-        "com.chrome.beta" to listOf("url_bar", "display_url"),
-        "org.chromium.chrome" to listOf("url_bar", "display_url"),
-        // Brave
-        "com.brave.browser" to listOf("url_bar", "display_url"),
-        "com.brave.browser_beta" to listOf("url_bar", "display_url"),
-        "com.brave.browser_nightly" to listOf("url_bar", "display_url"),
-        // Samsung Internet
-        "com.sec.android.app.sbrowser" to listOf("location_bar_edit_text"),
-        // Microsoft Edge
-        "com.microsoft.emmx" to listOf("url_bar"),
-        // Opera variants
-        "com.opera.browser" to listOf("url_field"),
-        "com.opera.browser.beta" to listOf("url_field"),
-        "com.opera.mini.native" to listOf("url_field"),
-        "com.opera.mini.native.beta" to listOf("url_field"),
-        "com.opera.touch" to listOf("addressbarEdit"),
-        // Vivaldi
-        "com.vivaldi.browser" to listOf("url_bar", "display_url"),
-        // Kiwi Browser
-        "com.kiwibrowser.browser" to listOf("url_bar", "display_url"),
-        // DuckDuckGo
-        "com.duckduckgo.mobile.android" to listOf("omnibarTextInput"),
-        // Ecosia
-        "com.ecosia.android" to listOf("url_bar"),
-        // Huawei Browser
-        "com.huawei.browser" to listOf("url_bar"),
-        // Android system browser (AOSP)
-        "com.android.browser" to listOf("url"),
-        // Google Search app (in-app browser)
-        "com.google.android.googlequicksearchbox" to listOf("googleapp_srp_search_box_text"),
-    )
-
-    private fun isSupportedBrowser(packageName: String): Boolean {
-        return packageName in browserUrlViewIds
-    }
+    private fun isSupportedBrowser(packageName: String): Boolean =
+        BrowserUrlParser.isSupportedBrowser(packageName)
 
     private fun navigateBrowserToBlank(browserPackage: String) {
         try {
@@ -209,7 +166,7 @@ class BlockerService : AccessibilityService() {
         val root = rootInActiveWindow ?: return null
         try {
             val pkg = event.packageName?.toString() ?: return null
-            val viewIds = browserUrlViewIds[pkg] ?: return null
+            val viewIds = BrowserUrlParser.browserUrlViewIds[pkg] ?: return null
             val knownUrlViewIds = viewIds.map { "$pkg:id/$it" } + viewIds
 
             // First try the standard API with fully-qualified resource IDs
@@ -250,13 +207,7 @@ class BlockerService : AccessibilityService() {
                 val rawText = node.text?.toString()?.takeIf { it.isNotBlank() }
                     ?: node.contentDescription?.toString()
                 if (rawText != null) {
-                    val words = rawText.split("\\s+".toRegex())
-                    for (word in words) {
-                        val cleanWord = word.trimEnd('.', ',')
-                        if (isValidUrlFormat(cleanWord)) {
-                            return cleanWord
-                        }
-                    }
+                    BrowserUrlParser.findUrlInText(rawText)?.let { return it }
                 }
             } finally {
                 node.recycle()
@@ -283,27 +234,9 @@ class BlockerService : AccessibilityService() {
         }
     }
 
-    private fun isValidUrlFormat(text: String): Boolean {
-        val trimmed = text.trim()
-        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return true
-        if (trimmed.contains(" ") || trimmed.length < 4) return false
-        val domainPattern = Regex("^[a-zA-Z0-9][a-zA-Z0-9.-]*\\.[a-zA-Z]{2,}(/.*)?$")
-        return domainPattern.matches(trimmed)
-    }
-
-    private fun extractDomain(url: String): String? {
-        return try {
-            var normalizedUrl = url.trim()
-            if (!normalizedUrl.startsWith("http://") && !normalizedUrl.startsWith("https://")) {
-                normalizedUrl = "https://$normalizedUrl"
-            }
-            val uri = java.net.URI(normalizedUrl)
-            uri.host?.lowercase()?.removePrefix("www.")
-        } catch (e: Exception) {
-            Log.e(TAG, "Error extracting domain from URL: $url", e)
-            null
-        }
-    }
+    private fun extractDomain(url: String): String? =
+        BrowserUrlParser.extractDomain(url)
+            ?: run { Log.e(TAG, "Error extracting domain from URL: $url"); null }
 
     override fun onInterrupt() {}
 

--- a/tauri-plugin-android-blocker/android/src/main/java/net/kollnig/reddblockandroid/service/BrowserUrlParser.kt
+++ b/tauri-plugin-android-blocker/android/src/main/java/net/kollnig/reddblockandroid/service/BrowserUrlParser.kt
@@ -1,0 +1,114 @@
+package net.kollnig.reddblockandroid.service
+
+/**
+ * Pure URL-bar parsing used by [BlockerService]: which browsers are supported,
+ * which view IDs hold their URL, and how to turn that view's raw text into a
+ * blockable domain.
+ *
+ * Deliberately free of Android framework types so it can be covered by JVM unit
+ * tests (`BrowserUrlParserTest`) — this is the step that decides whether a
+ * website block fires at all, and a browser-specific quirk here silently
+ * disables blocking for that browser with no other symptom.
+ */
+object BrowserUrlParser {
+
+    /** Maps browser package names to their URL bar view IDs */
+    val browserUrlViewIds = mapOf(
+        // Firefox variants
+        "org.mozilla.firefox" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
+        "org.mozilla.firefox_beta" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
+        "org.mozilla.fenix" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
+        "org.mozilla.fenix.nightly" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
+        "org.mozilla.focus" to listOf("mozac_browser_toolbar_url_view", "url_bar_title", "ADDRESSBAR_URL_BOX"),
+        // Chrome / Chromium
+        "com.android.chrome" to listOf("url_bar", "origin", "display_url"),
+        "com.chrome.beta" to listOf("url_bar", "display_url"),
+        "org.chromium.chrome" to listOf("url_bar", "display_url"),
+        // Brave
+        "com.brave.browser" to listOf("url_bar", "display_url"),
+        "com.brave.browser_beta" to listOf("url_bar", "display_url"),
+        "com.brave.browser_nightly" to listOf("url_bar", "display_url"),
+        // Samsung Internet
+        "com.sec.android.app.sbrowser" to listOf("location_bar_edit_text"),
+        "com.sec.android.app.sbrowser.beta" to listOf("location_bar_edit_text"),
+        // Microsoft Edge
+        "com.microsoft.emmx" to listOf("url_bar"),
+        // Opera variants
+        "com.opera.browser" to listOf("url_field"),
+        "com.opera.browser.beta" to listOf("url_field"),
+        "com.opera.mini.native" to listOf("url_field"),
+        "com.opera.mini.native.beta" to listOf("url_field"),
+        "com.opera.touch" to listOf("addressbarEdit"),
+        // Vivaldi
+        "com.vivaldi.browser" to listOf("url_bar", "display_url"),
+        // Kiwi Browser
+        "com.kiwibrowser.browser" to listOf("url_bar", "display_url"),
+        // DuckDuckGo
+        "com.duckduckgo.mobile.android" to listOf("omnibarTextInput"),
+        // Ecosia
+        "com.ecosia.android" to listOf("url_bar"),
+        // Huawei Browser
+        "com.huawei.browser" to listOf("url_bar"),
+        // Android system browser (AOSP)
+        "com.android.browser" to listOf("url"),
+        // Google Search app (in-app browser)
+        "com.google.android.googlequicksearchbox" to listOf("googleapp_srp_search_box_text"),
+    )
+
+    fun isSupportedBrowser(packageName: String): Boolean = packageName in browserUrlViewIds
+
+    /**
+     * Picks the first URL-looking word out of a URL bar's raw text, or null if
+     * there is none (empty bar, search query, new tab page).
+     */
+    fun findUrlInText(rawText: String): String? {
+        val words = stripInvisibleMarks(rawText).split("\\s+".toRegex())
+        for (word in words) {
+            val cleanWord = word.trimEnd('.', ',')
+            if (isValidUrlFormat(cleanWord)) return cleanWord
+        }
+        return null
+    }
+
+    /**
+     * Removes bidi/zero-width control characters from URL-bar text:
+     * U+200B..U+200F (zero-width space/joiners, LTR/RTL mark),
+     * U+202A..U+202E (embeddings/override), U+2066..U+2069 (isolates), U+FEFF (BOM).
+     *
+     * Samsung Internet prefixes its `location_bar_edit_text` with a LEFT-TO-RIGHT
+     * MARK (U+200E) — invisible, but enough to make the domain fail
+     * [isValidUrlFormat], so Samsung Internet never blocked before this. Other
+     * browsers wrap URLs in bidi isolates for the same spoofing-protection reason.
+     */
+    fun stripInvisibleMarks(text: String): String =
+        if (text.any { isInvisibleMark(it) }) text.filterNot { isInvisibleMark(it) } else text
+
+    private fun isInvisibleMark(c: Char): Boolean {
+        val code = c.code
+        return code in 0x200B..0x200F ||
+            code in 0x202A..0x202E ||
+            code in 0x2066..0x2069 ||
+            code == 0xFEFF
+    }
+
+    fun isValidUrlFormat(text: String): Boolean {
+        val trimmed = text.trim()
+        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return true
+        if (trimmed.contains(" ") || trimmed.length < 4) return false
+        val domainPattern = Regex("^[a-zA-Z0-9][a-zA-Z0-9.-]*\\.[a-zA-Z]{2,}(/.*)?$")
+        return domainPattern.matches(trimmed)
+    }
+
+    /** Lowercased host with "www." stripped, or null if [url] has no parseable host. */
+    fun extractDomain(url: String): String? {
+        return try {
+            var normalizedUrl = stripInvisibleMarks(url).trim()
+            if (!normalizedUrl.startsWith("http://") && !normalizedUrl.startsWith("https://")) {
+                normalizedUrl = "https://$normalizedUrl"
+            }
+            java.net.URI(normalizedUrl).host?.lowercase()?.removePrefix("www.")
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/tauri-plugin-android-blocker/android/src/test/java/net/kollnig/reddblockandroid/service/BrowserUrlParserTest.kt
+++ b/tauri-plugin-android-blocker/android/src/test/java/net/kollnig/reddblockandroid/service/BrowserUrlParserTest.kt
@@ -1,0 +1,95 @@
+package net.kollnig.reddblockandroid.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the URL-bar parsing that decides whether a website block fires.
+ *
+ * The [REAL_URL_BAR_TEXTS] fixtures are verbatim `text` values dumped from the
+ * accessibility tree of browsers on a real device (`uiautomator dump`), quirks
+ * included — that is the only way a browser-specific oddity like Samsung
+ * Internet's invisible U+200E prefix shows up, since it fails silently: the
+ * browser stays in the supported-package map and simply never blocks.
+ *
+ * When adding a browser, dump its URL bar on a device and add the raw text here.
+ */
+class BrowserUrlParserTest {
+
+    /** package -> (raw URL-bar text as dumped, expected blockable domain) */
+    private val REAL_URL_BAR_TEXTS = listOf(
+        // Samsung Internet 30.0.0.67 prefixes a LEFT-TO-RIGHT MARK (U+200E).
+        Triple("com.sec.android.app.sbrowser", "\u200Ebbc.com", "bbc.com"),
+        Triple("com.sec.android.app.sbrowser", "\u200Eft.com", "ft.com"),
+        // DuckDuckGo 5.291.1 reports the bare domain.
+        Triple("com.duckduckgo.mobile.android", "example.com", "example.com"),
+        // Chromium-family browsers show the domain, sometimes with the scheme.
+        Triple("com.android.chrome", "https://www.bbc.co.uk/news", "bbc.co.uk"),
+        Triple("com.brave.browser", "bbc.co.uk", "bbc.co.uk"),
+        // Firefox reports the full URL.
+        Triple("org.mozilla.firefox", "https://reddit.com/r/all", "reddit.com"),
+    )
+
+    @Test
+    fun `real device URL bar text yields the blockable domain`() {
+        for ((pkg, rawText, expectedDomain) in REAL_URL_BAR_TEXTS) {
+            assertTrue("$pkg should be a supported browser", BrowserUrlParser.isSupportedBrowser(pkg))
+            val url = BrowserUrlParser.findUrlInText(rawText)
+            assertEquals("no URL found in $pkg text ${rawText.escaped()}", true, url != null)
+            assertEquals("wrong domain for $pkg text ${rawText.escaped()}",
+                expectedDomain, BrowserUrlParser.extractDomain(url!!))
+        }
+    }
+
+    @Test
+    fun `invisible bidi and zero-width marks are stripped`() {
+        // U+200E LTR mark (Samsung), U+200F RTL mark, U+2066..U+2069 isolates,
+        // U+202A..U+202E embeddings, U+200B zero-width space, U+FEFF BOM.
+        val wrapped = "\u2066\u202A\u200Ereddit.com\u200B\u202C\u2069\uFEFF"
+        assertEquals("reddit.com", BrowserUrlParser.stripInvisibleMarks(wrapped))
+        assertEquals("reddit.com", BrowserUrlParser.extractDomain(BrowserUrlParser.findUrlInText(wrapped)!!))
+    }
+
+    @Test
+    fun `visible text is left untouched`() {
+        assertEquals("bbc.co.uk/news", BrowserUrlParser.stripInvisibleMarks("bbc.co.uk/news"))
+    }
+
+    @Test
+    fun `non-URL bar contents are not treated as URLs`() {
+        // Search queries, hints and empty bars must not produce a domain —
+        // a false positive here blocks a page the user never visited.
+        for (text in listOf("", "   ", "Search or type URL", "how to focus", "reddit", "3.5")) {
+            assertNull("unexpectedly parsed a URL out of ${text.escaped()}",
+                BrowserUrlParser.findUrlInText(text))
+        }
+    }
+
+    @Test
+    fun `domains are normalised for matching`() {
+        assertEquals("reddit.com", BrowserUrlParser.extractDomain("https://WWW.Reddit.com/r/all"))
+        assertEquals("old.reddit.com", BrowserUrlParser.extractDomain("old.reddit.com/r/all"))
+        assertEquals("reddit.com", BrowserUrlParser.extractDomain("reddit.com"))
+        assertNull(BrowserUrlParser.extractDomain("not a url"))
+    }
+
+    @Test
+    fun `URL is found among surrounding words`() {
+        // Some browsers expose "Secure connection example.com" style content descriptions.
+        assertEquals("example.com", BrowserUrlParser.findUrlInText("Secure connection example.com"))
+        assertEquals("example.com", BrowserUrlParser.findUrlInText("Visited example.com."))
+    }
+
+    @Test
+    fun `every supported browser has at least one view id`() {
+        for ((pkg, ids) in BrowserUrlParser.browserUrlViewIds) {
+            assertTrue("$pkg has no URL bar view ids", ids.isNotEmpty())
+            assertTrue("$pkg has a blank view id", ids.all { it.isNotBlank() })
+        }
+    }
+
+    private fun String.escaped() =
+        map { if (it.code in 0x20..0x7E) it.toString() else "\\u%04X".format(it.code) }.joinToString("")
+}

--- a/testing.md
+++ b/testing.md
@@ -241,11 +241,38 @@ Run these before merging changes to `web_automation.rs`, `native_host.rs`,
 
 ---
 
+## Android Kotlin unit tests
+
+Android website blocking hinges on reading the URL out of each browser's URL
+bar via the accessibility tree. That parsing lives in
+`tauri-plugin-android-blocker/.../service/BrowserUrlParser.kt` — deliberately
+free of Android framework types so it runs as a plain JVM test:
+
+```
+cd src-tauri/gen/android && ./gradlew :tauri-plugin-android-blocker:testDebugUnitTest
+```
+
+`BrowserUrlParserTest` pins **verbatim URL-bar strings dumped from real
+devices** (`adb shell uiautomator dump`), quirks included. This matters because
+a browser-specific quirk here fails *silently*: the browser stays in the
+supported-package map, extraction just returns nothing, and that browser never
+blocks with no error anywhere. That is exactly how Samsung Internet's invisible
+`U+200E` LTR-mark prefix went unnoticed.
+
+**When adding or fixing a browser:** open a site in it, `uiautomator dump` the
+tree, add the raw `text` value of its URL-bar node as a fixture, then verify on
+a device (`logcat -s BlockerService` should log `Blocking website …`). The unit
+test proves parsing; only the device proves the accessibility event actually
+arrives and the friction gate launches.
+
+---
+
 ## Tier Comparison
 
 - **Tier 1 (logic)**: high breadth of logic permutations, zero system mutation.
 - **Tier 2 (integration)**: moderate breadth, Tauri command paths with the `current_blocking` enforcement snapshot as read-back.
 - **Rust unit tests**: enforcement decision logic (URL matching, allowlist composition, payload derivation).
+- **Android Kotlin unit tests**: browser URL-bar parsing (`BrowserUrlParser`), against fixtures dumped from real devices.
 - **Manual checklist**: required for website enforcement, permissions, enforcer, and visual UX.
 
 Recommended stance:


### PR DESCRIPTION
## What

Closes #74.

Samsung Internet never blocked websites on Android, even though it was already in the supported-browser map. DuckDuckGo, which prompted this investigation, turned out to already work — verified on device.

## Root cause

Samsung Internet prefixes its `location_bar_edit_text` with an invisible **LEFT-TO-RIGHT MARK (U+200E)**. Dumped live from a Pixel 8 (Samsung Internet 30.0.0.67):

```
location_bar_edit_text  text = "‎bbc.com"   (first char = 0x200E)
```

That leading char fails `isValidUrlFormat`'s `^[a-zA-Z0-9]` anchor, so no domain was ever extracted. The browser stayed in the map, extraction just returned nothing, and blocking silently did nothing — no error, no log.

## Fix

Strip bidi/zero-width controls (U+200B–200F, U+202A–202E, U+2066–2069, U+FEFF) from URL-bar text before parsing. Other browsers wrap URLs in bidi isolates for the same spoofing-protection reason, so this is not Samsung-specific. Also adds `com.sec.android.app.sbrowser.beta`.

## Tests

The plugin had no Kotlin tests, and this bug class fails silently — the worst combination. So the parsing moves out of `BlockerService` into a framework-free `BrowserUrlParser`, covered by `BrowserUrlParserTest`:

```bash
cd src-tauri/gen/android && ./gradlew :tauri-plugin-android-blocker:testDebugUnitTest
```

Fixtures are **verbatim URL-bar strings dumped from real devices** (`uiautomator dump`), quirks included — that is the only way a quirk like the U+200E prefix surfaces. Also covers false positives: search queries and hints must never resolve to a domain.

7 tests pass. Confirmed the suite is real by temporarily disabling the fix — 2 tests fail, then pass again on restore.

## Device verification

Pixel 8, debug build, blocked domain `bbc.co.uk`:

```
com.sec.android.app.sbrowser    -> UnlockActivity   "Blocking website bbc.co.uk"   (was broken)
com.duckduckgo.mobile.android   -> UnlockActivity   "Blocking website bbc.co.uk"   (already worked)
com.brave.browser               -> UnlockActivity   (app block, unaffected)
```

Docs updated in `testing.md` and `AGENTS.md`, including the workflow for adding a browser: the unit test proves parsing, only a device proves the accessibility event arrives and the gate launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
